### PR TITLE
chore: fix whitespace in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,29 +2,29 @@ name: Feature request
 description: Propose a new feature or capability.
 labels: ["pending triage"]
 body:
-	- type: textarea
-		id: problem
-		attributes:
-			label: Problem statement / motivation
-			description: What problem are you trying to solve and for whom?
-			placeholder: The current experience makes it hard to ...
-		validations:
-			required: true
-	- type: textarea
-		id: solution
-		attributes:
-			label: Proposed solution
-			description: Describe the solution or behavior you want.
-			placeholder: We should add ...
-		validations:
-			required: true
-	- type: textarea
-		id: alternatives
-		attributes:
-			label: Alternatives considered
-			description: Optional. Other approaches you considered.
-	- type: textarea
-		id: context
-		attributes:
-			label: Additional context
-			description: Optional. Links, references, or examples.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement / motivation
+      description: What problem are you trying to solve and for whom?
+      placeholder: The current experience makes it hard to ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution or behavior you want.
+      placeholder: We should add ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Other approaches you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Optional. Links, references, or examples.

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -2,27 +2,27 @@ name: Improvement
 description: Enhance an existing feature or behavior.
 labels: ["pending triage"]
 body:
-	- type: textarea
-		id: current
-		attributes:
-			label: What exists today
-			description: Describe the current behavior or feature.
-			placeholder: Today, ...
-		validations:
-			required: true
-	- type: textarea
-		id: change
-		attributes:
-			label: What should change
-			description: Describe the improvement you want.
-			placeholder: We should change ...
-		validations:
-			required: true
-	- type: textarea
-		id: why
-		attributes:
-			label: Why
-			description: Why is this change needed or valuable?
-			placeholder: This matters because ...
-		validations:
-			required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: What exists today
+      description: Describe the current behavior or feature.
+      placeholder: Today, ...
+    validations:
+      required: true
+  - type: textarea
+    id: change
+    attributes:
+      label: What should change
+      description: Describe the improvement you want.
+      placeholder: We should change ...
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why is this change needed or valuable?
+      placeholder: This matters because ...
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
Issue templates for improvements and features are not shown right now, because the whitespace used was incorrect.

## Related issue(s)
Closes #7

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [ ] i18n keys added/updated (if needed)
- [x] No breaking changes
