### PR TITLE
fix: accent color buttons invisible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 # Playwright
 playwright-report/
 test-results/
+
+# Claude
+CLAUDE.md

--- a/app/components/settings/AppearanceSection.vue
+++ b/app/components/settings/AppearanceSection.vue
@@ -105,7 +105,7 @@ function selectLocale(code: 'en' | 'de') {
             role="radio"
             :aria-checked="currentColor === color.name"
             :aria-label="color.name"
-            :class="color.class"
+            :style="{ backgroundColor: color.hex }"
             class="size-8 rounded-full transition-transform hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary flex items-center justify-center cursor-pointer"
             @click="selectColor(color.name)"
           >

--- a/app/components/ui/AccentColorPicker.vue
+++ b/app/components/ui/AccentColorPicker.vue
@@ -54,7 +54,7 @@ function resetColor() {
         <button
           v-for="color in accentColors"
           :key="color.name"
-          :class="color.class"
+          :style="{ backgroundColor: color.hex }"
           class="size-8 rounded-full transition-transform hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary flex items-center justify-center"
           :aria-label="color.name"
           @click="selectColor(color.name)"

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -11,12 +11,12 @@ export const defaultUserSettings: UserSettings = {
 }
 
 export const accentColors = [
-  { name: 'red', class: 'bg-red-500' },
-  { name: 'orange', class: 'bg-orange-500' },
-  { name: 'amber', class: 'bg-amber-500' },
-  { name: 'emerald', class: 'bg-emerald-500' },
-  { name: 'cyan', class: 'bg-cyan-500' },
-  { name: 'blue', class: 'bg-blue-500' },
-  { name: 'violet', class: 'bg-violet-500' },
-  { name: 'rose', class: 'bg-rose-500' },
+  { name: 'red', hex: '#ef4444' },
+  { name: 'orange', hex: '#f97316' },
+  { name: 'amber', hex: '#f59e0b' },
+  { name: 'emerald', hex: '#10b981' },
+  { name: 'cyan', hex: '#06b6d4' },
+  { name: 'blue', hex: '#3b82f6' },
+  { name: 'violet', hex: '#8b5cf6' },
+  { name: 'rose', hex: '#f43f5e' },
 ] as const


### PR DESCRIPTION
## Summary
- Change `class` property to `hex`, because tailwindcss  cannot handle it

## Related issue(s)
Closes #16 

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI
