### PR TITLE
fix: add missing translation for theme.system

### DIFF
--- a/app/components/settings/ThemePicker.vue
+++ b/app/components/settings/ThemePicker.vue
@@ -9,10 +9,18 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+type ThemeValue = 'light' | 'dark' | 'system'
+
+const themeLabels = computed<Record<ThemeValue, string>>(() => ({
+  light: t('theme.light'),
+  dark: t('theme.dark'),
+  system: t('theme.system'),
+}))
+
 const themes = [
-  { value: 'light', icon: 'i-lucide-sun', labelKey: 'theme.light' },
-  { value: 'dark', icon: 'i-lucide-moon', labelKey: 'theme.dark' },
-  { value: 'system', icon: 'i-lucide-monitor', labelKey: 'theme.system' },
+  { value: 'light', icon: 'i-lucide-sun' },
+  { value: 'dark', icon: 'i-lucide-moon' },
+  { value: 'system', icon: 'i-lucide-monitor' },
 ] as const
 </script>
 
@@ -27,7 +35,7 @@ const themes = [
       :key="theme.value"
       role="radio"
       :aria-checked="modelValue === theme.value"
-      :aria-label="t(theme.labelKey)"
+      :aria-label="themeLabels[theme.value]"
       class="rounded-xl border-2 p-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
       :class="modelValue === theme.value
         ? 'border-primary bg-primary/5'
@@ -72,7 +80,7 @@ const themes = [
           :name="theme.icon"
           class="size-4"
         />
-        <span class="text-sm font-medium">{{ t(theme.labelKey) }}</span>
+        <span class="text-sm font-medium">{{ themeLabels[theme.value] }}</span>
       </div>
     </button>
   </div>

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -23,7 +23,8 @@
   },
   "theme": {
     "light": "Hell",
-    "dark": "Dunkel"
+    "dark": "Dunkel",
+    "system": "System"
   },
   "time": {
     "justNow": "gerade eben",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -23,7 +23,8 @@
   },
   "theme": {
     "light": "Light",
-    "dark": "Dark"
+    "dark": "Dark",
+    "system": "System"
   },
   "time": {
     "justNow": "just now",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -78,6 +78,9 @@
         },
         "dark": {
           "type": "string"
+        },
+        "system": {
+          "type": "string"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
* Refactored usage of translations
* Added missing translations
* Updated schema

## Related issue(s)
Closes #36 

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [X] i18n keys added/updated (if needed)
- [ ] No breaking changes

## Screenshots
(If UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select a "System" theme option that automatically matches their device's light or dark mode preference, eliminating the need for manual theme switching.
  * Theme labels are now fully localized, with support for English and German translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->