### PR TITLE
chore: adjust i18n validation to allow dynamic keys if there are matching translations

### DIFF
--- a/app/components/repo/RepoNotificationList.vue
+++ b/app/components/repo/RepoNotificationList.vue
@@ -24,43 +24,10 @@ const typeColor: Record<string, string> = {
   CheckSuite: 'text-amber-500',
 }
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 
 function reasonLabel(reason: string): string {
-  switch (reason) {
-    case 'mention':
-      return t('repos.reason.mention')
-    case 'author':
-      return t('repos.reason.author')
-    case 'comment':
-      return t('repos.reason.comment')
-    case 'subscribed':
-      return t('repos.reason.subscribed')
-    case 'review_requested':
-      return t('repos.reason.review_requested')
-    case 'assign':
-      return t('repos.reason.assign')
-    case 'state_change':
-      return t('repos.reason.state_change')
-    case 'ci_activity':
-      return t('repos.reason.ci_activity')
-    case 'approval_requested':
-      return t('repos.reason.approval_requested')
-    case 'invitation':
-      return t('repos.reason.invitation')
-    case 'manual':
-      return t('repos.reason.manual')
-    case 'member_feature_requested':
-      return t('repos.reason.member_feature_requested')
-    case 'security_advisory_credit':
-      return t('repos.reason.security_advisory_credit')
-    case 'security_alert':
-      return t('repos.reason.security_alert')
-    case 'team_mention':
-      return t('repos.reason.team_mention')
-    default:
-      return t('repos.reason.unknown')
-  }
+  return te(`repos.reason.${reason}`) ? t(`repos.reason.${reason}`) : t('repos.reason.unknown')
 }
 </script>
 

--- a/scripts/generate-i18n-schema.ts
+++ b/scripts/generate-i18n-schema.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable no-console */
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/scripts/utils/i18n.ts
+++ b/scripts/utils/i18n.ts
@@ -1,0 +1,39 @@
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createI18NReport } from 'vue-i18n-extract'
+
+export const LOCALES_DIRECTORY = fileURLToPath(new URL('../../i18n/locales', import.meta.url))
+const VUE_FILES_GLOB = './app/**/*.?(vue|ts|js)'
+
+export const createI18nReport = async () => {
+  const { missingKeys, unusedKeys, maybeDynamicKeys } = await createI18NReport({
+    vueFiles: VUE_FILES_GLOB,
+    languageFiles: join(LOCALES_DIRECTORY, '*.json'),
+    exclude: ['$schema'],
+  })
+
+  const dynamicKeysWithoutTranslation = new Array(...maybeDynamicKeys)
+
+  const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  const actualUnusedKeys = unusedKeys
+    .filter(key => !maybeDynamicKeys.some((dynamicKey) => {
+      const parts = dynamicKey.path.split(/\$\{[^}]+\}/g)
+      const pattern = `^${parts.map(escapeRegex).join('.*')}$`
+      const matcher = new RegExp(pattern)
+      if (matcher.test(key.path)) {
+        if (dynamicKeysWithoutTranslation.includes(dynamicKey)) {
+          const index = dynamicKeysWithoutTranslation.indexOf(dynamicKey)
+          dynamicKeysWithoutTranslation.splice(index, 1)
+        }
+        return true
+      }
+      else {
+        return false
+      }
+    }))
+
+  const unusedFalsePositives = unusedKeys.filter(k => !actualUnusedKeys.includes(k))
+  const dynamicKeyFalsePositives = maybeDynamicKeys.filter(k => !dynamicKeysWithoutTranslation.includes(k))
+  return { missingKeys, actualUnusedKeys, unusedFalsePositives, dynamicKeysWithoutTranslation, dynamicKeyFalsePositives }
+}


### PR DESCRIPTION
## Summary
Dynamic translations were not allowed, but we want to use them. Now they are printed out as a warning, since we still should use them with caution. Unused keys that match a dynamic key will not let the validation fail.

## Related issue(s)
No issue

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [X] CI

## Checklist
- [ ] Tests added/updated
- [ ] i18n keys added/updated (if needed)
- [ ] No breaking changes

## Screenshots
(If UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved translation handling with better fallback support when encountering missing or unknown keys.

* **Refactor**
  * Enhanced translation validation and analysis tooling with better categorization of missing, unused, and dynamic keys.
  * Simplified i18n utility architecture for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->