### PR TITLE
fix: Replace / in cache key to prevent errors for local development on Windows

### DIFF
--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -280,10 +280,11 @@ function buildCacheKey(
   endpoint: string,
   params?: Record<string, string | number>,
 ): string {
+  const endpointKey = endpoint.replaceAll('/', '~')
   const paramStr = params
     ? ':' + Object.entries(params).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => `${k}=${v}`).join('&')
     : ''
-  return `github-cache:${userId}:${endpoint}${paramStr}`
+  return `github-cache:${userId}:${endpointKey}${paramStr}`
 }
 
 function buildHeaders(token: string): Record<string, string> {


### PR DESCRIPTION
## Summary
Windows struggled with the cache keys since they contained `/`. Replacing `/` with `~` fixes the issue.

`ℹ Error: EISDIR: illegal operation on a directory, open '.\.data\storage\github-cache\5129082\user'`

## Related issue(s)
No issue

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [ ] i18n keys added/updated (if needed)
- [ ] No breaking changes

## Screenshots
(If UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache key generation for enhanced reliability in backend operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->