### PR TITLE
fix: link to flumen issues

### DIFF
--- a/app/components/repo/RepoCard.vue
+++ b/app/components/repo/RepoCard.vue
@@ -21,8 +21,15 @@ const activityTooltip = computed(() => {
 })
 
 const { isPinned, toggle: togglePin } = usePinnedRepos()
+const localePath = useLocalePath()
+const issueStore = useIssueStore()
 
 const expandedSection = ref<'issues' | 'prs' | 'notifications' | null>(null)
+
+function navigateToIssues() {
+  issueStore.selectRepo(props.repo.fullName)
+  navigateTo(localePath('/issues'))
+}
 
 function toggleSection(section: 'issues' | 'prs' | 'notifications') {
   expandedSection.value = expandedSection.value === section ? null : section
@@ -30,7 +37,10 @@ function toggleSection(section: 'issues' | 'prs' | 'notifications') {
 </script>
 
 <template>
-  <div class="px-4 py-3 hover:bg-elevated transition-colors">
+  <div
+    class="px-4 py-3 hover:bg-elevated transition-colors cursor-pointer"
+    @click="navigateToIssues"
+  >
     <div class="flex items-start gap-3">
       <!-- Activity dot -->
       <UTooltip
@@ -48,14 +58,12 @@ function toggleSection(section: 'issues' | 'prs' | 'notifications') {
       <div class="min-w-0 flex-1">
         <!-- Row 1: Name + badges + time -->
         <div class="flex items-center gap-2">
-          <NuxtLink
-            :to="repo.htmlUrl"
-            external
-            target="_blank"
-            class="font-semibold text-highlighted truncate hover:underline"
+          <button
+            class="font-semibold text-highlighted truncate hover:underline cursor-pointer text-left"
+            @click="navigateToIssues"
           >
             {{ repo.name }}
-          </NuxtLink>
+          </button>
 
           <UBadge
             v-if="repo.archived"


### PR DESCRIPTION
## Summary
- Link from repo click to flumen issue, no longer GitHub

## Related issue(s)
Closes #123

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [ ] i18n keys added/updated (if needed)
- [ ] No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repo cards are now fully clickable to navigate directly to the repository's issues page.
  * Repository names now navigate to the issues view rather than external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->