### PR TITLE
fix: async import of emoji picker to solve import errors

### DIFF
--- a/app/components/ui/StatusDialog.vue
+++ b/app/components/ui/StatusDialog.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { VuemojiPicker } from 'vuemoji-picker'
 import githubEmojiDataUrl from 'emoji-picker-element-data/en/github/data.json?url'
 import { STATUS_PRESETS, expiryToDate, shortcodeToUnicode, type ExpiryOption } from '~~/shared/types/status'
+
+const VuemojiPicker = defineAsyncComponent(async () => {
+  return (await import('vuemoji-picker')).VuemojiPicker
+})
 
 const open = defineModel<boolean>('open', { default: false })
 


### PR DESCRIPTION
## Summary
```
Error {▼
stack: "Cannot find module 'F:\Git\flumen\flumen.dev\node_modules\.pnpm\[vuemoji-picker@0.3.2_vue](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)@[3.5.28_typescript@5.9](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).3_\node_modules\emoji-picker-element\picker' imported from F:\Git\flumen\flumen.dev\node_modules\.pnpm\[vuemoji-picker@0.3.2_vue](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)@[3.5.28_typescript@5.9](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).3_\node_modules\vuemoji-picker\dist\index.js\n" +
'Did you mean to import "emoji-picker-element/picker.js"?\n' +
' at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n' +
' at moduleResolve (node:internal/modules/esm/resolve:864:10)\n' +
' at defaultResolve (node:internal/modules/esm/resolve:990:11)\n' +
' at #cachedDefaultResolve (node:internal/modules/esm/loader:757:20)\n' +
' at ModuleLoader.resolve (node:internal/modules/esm/loader:734:38)\n' +
' at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:317:38)\n' +
' at #link (node:internal/modules/esm/module_job:208:49)\n' +
' at process.processTicksAndRejections (node:internal/process/task_queues:105:5)',
code: 'ERR_MODULE_NOT_FOUND',
url: 'file:///F:/Git/flumen/flumen.dev/node_modules/.pnpm/[vuemoji-picker@0.3.2_vue](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)@[3.5.28_typescript@5.9](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).3_/node_modules/emoji-picker-element/picker',
message: "Cannot find module
'F:\Git\flumen\flumen.dev\node_modules\.pnpm\[vuemoji-picker@0.3.2_vue](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)@[3.5.28_typescript@5.9](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).3_\node_modules\emoji-picker-element\picker'
imported from
F:\Git\flumen\flumen.dev\node_modules\.pnpm\[vuemoji-picker@0.3.2_vue](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)@[3.5.28_typescript@5.9](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).3_\node_modules\vuemoji-picker\dist\index.js\n"
+

'Did you mean to import "emoji-picker-element/picker.js"?',
}
``` 

This error was fixed by importing the emoji-picker as an async component.


## Related issue(s)
None

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [ ] i18n keys added/updated (if needed)
- [ ] No breaking changes

## Screenshots
(If UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized component loading strategy for improved initial application startup performance through lazy loading implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->