### PR TITLE
feat: add statistics summary badges

### DIFF
--- a/app/components/focus/InboxSection.vue
+++ b/app/components/focus/InboxSection.vue
@@ -202,6 +202,9 @@ onUnmounted(() => window.removeEventListener('keydown', onQuestionMark))
       </button>
     </div>
 
+    <!-- Summary stats -->
+    <FocusInboxSummary />
+
     <!-- Batch action bar -->
     <div
       v-if="store.selectedKeys.size > 0"

--- a/app/components/focus/InboxSummary.vue
+++ b/app/components/focus/InboxSummary.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+const { t } = useI18n()
+const store = useFocusStore()
+
+interface Pill {
+  label: string
+  color: 'neutral' | 'error' | 'warning'
+}
+
+const pills = computed<Pill[]>(() => {
+  const prs = store.visiblePRs
+  const issues = store.visibleIssues
+  if (prs.length + issues.length === 0) return []
+
+  let oldestDays = 0
+  let failingCI = 0
+  let pendingCI = 0
+  let changesRequested = 0
+  let conflicts = 0
+
+  for (const pr of prs) {
+    const days = Math.floor((Date.now() - new Date(pr.updatedAt).getTime()) / 86_400_000)
+    if (days > oldestDays) oldestDays = days
+    if (pr.ciStatus === 'FAILURE') failingCI++
+    if (pr.ciStatus === 'PENDING') pendingCI++
+    if (pr.reviewDecision === 'CHANGES_REQUESTED') changesRequested++
+    if (pr.mergeable === 'CONFLICTING') conflicts++
+  }
+
+  const result: Pill[] = []
+  if (prs.length > 0)
+    result.push({ label: t('focus.inbox.summary.prs', { count: prs.length }), color: 'neutral' })
+  if (oldestDays > 0)
+    result.push({ label: t('focus.inbox.summary.oldest', { days: oldestDays }), color: 'neutral' })
+  if (failingCI > 0)
+    result.push({ label: t('focus.inbox.summary.ciFailing', { count: failingCI }), color: 'error' })
+  if (pendingCI > 0)
+    result.push({ label: t('focus.inbox.summary.ciPending', { count: pendingCI }), color: 'warning' })
+  if (changesRequested > 0)
+    result.push({ label: t('focus.inbox.summary.changesRequested', { count: changesRequested }), color: 'warning' })
+  if (conflicts > 0)
+    result.push({ label: t('focus.inbox.summary.conflicts', { count: conflicts }), color: 'error' })
+  if (issues.length > 0)
+    result.push({ label: t('focus.inbox.summary.issues', { count: issues.length }), color: 'neutral' })
+  return result
+})
+</script>
+
+<template>
+  <div
+    v-if="pills.length"
+    class="flex flex-wrap items-center gap-1.5 px-4 py-2 border-b border-default"
+  >
+    <UBadge
+      v-for="(pill, i) in pills"
+      :key="i"
+      :label="pill.label"
+      :color="pill.color"
+      variant="subtle"
+      size="sm"
+    />
+  </div>
+</template>

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -737,6 +737,15 @@
       "dismissSelected": "Auswahl ausblenden",
       "restoreSelected": "Auswahl wiederherstellen",
       "clearSelection": "Aufheben",
+      "summary": {
+        "prs": "{count} PR | {count} PRs",
+        "issues": "{count} Issue | {count} Issues",
+        "oldest": "ältester {days}T",
+        "ciFailing": "{count} CI fehlgeschlagen",
+        "ciPending": "{count} CI ausstehend",
+        "changesRequested": "{count} Änderungen angefragt",
+        "conflicts": "{count} Konflikt | {count} Konflikte"
+      },
       "shortcuts": {
         "title": "Tastenkürzel",
         "next": "Nächstes Element",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -737,6 +737,15 @@
       "dismissSelected": "Dismiss selected",
       "restoreSelected": "Restore selected",
       "clearSelection": "Clear",
+      "summary": {
+        "prs": "{count} PR | {count} PRs",
+        "issues": "{count} issue | {count} issues",
+        "oldest": "oldest {days}d",
+        "ciFailing": "{count} CI failing",
+        "ciPending": "{count} CI pending",
+        "changesRequested": "{count} changes requested",
+        "conflicts": "{count} conflict | {count} conflicts"
+      },
       "shortcuts": {
         "title": "Keyboard Shortcuts",
         "next": "Next item",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -2218,6 +2218,33 @@
             "clearSelection": {
               "type": "string"
             },
+            "summary": {
+              "type": "object",
+              "properties": {
+                "prs": {
+                  "type": "string"
+                },
+                "issues": {
+                  "type": "string"
+                },
+                "oldest": {
+                  "type": "string"
+                },
+                "ciFailing": {
+                  "type": "string"
+                },
+                "ciPending": {
+                  "type": "string"
+                },
+                "changesRequested": {
+                  "type": "string"
+                },
+                "conflicts": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
             "shortcuts": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
## Summary
- Badges for summary statistics

## Related issue(s)
Closes #121 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI

## Checklist
- [ ] Tests added/updated
- [x] i18n keys added/updated (if needed)
- [ ] No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inbox summary section displaying key metrics at a glance: PR count, issue count, oldest item age, CI failures, pending CI checks, changes requested, and merge conflicts.
  * Summary information presented as visual badges for quick status reference.
  * Added support for German and English translations for the new summary section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->