### PR TITLE
feat(issues): inline last-comment snippet on rows

### DIFF
--- a/app/components/issue/IssueRow.vue
+++ b/app/components/issue/IssueRow.vue
@@ -11,6 +11,7 @@ const localePath = useLocalePath()
 const { open: openProfile } = useUserProfileDialog()
 const createdAgo = useTimeAgo(computed(() => props.issue.createdAt))
 const updatedAgo = useTimeAgo(computed(() => props.issue.updatedAt))
+const lastCommentAgo = useTimeAgo(computed(() => props.issue.lastComment?.createdAt ?? Date.now()))
 
 const stateIcon = computed(() => getIssueStateIcon(props.issue.state, props.issue.stateReason))
 const stateColor = computed(() => getIssueStateColor(props.issue.state, props.issue.stateReason))
@@ -77,10 +78,23 @@ function navigate() {
         />
       </div>
 
-      <!-- Row 2: Meta -->
+      <!-- Row 2: Last-comment quote (when available) -->
+      <div
+        v-if="issue.lastComment"
+        class="flex items-baseline gap-2 mt-1 text-xs min-w-0"
+      >
+        <span
+          class="flex-1 min-w-0 italic text-muted/80 border-l-2 border-primary/30 pl-2 truncate"
+        >&ldquo;{{ issue.lastComment.snippet }}&rdquo;</span>
+        <span class="shrink-0 text-muted/60 whitespace-nowrap">
+          {{ issue.lastComment.author.login }} · {{ lastCommentAgo }}
+        </span>
+      </div>
+
+      <!-- Row 3: Meta -->
       <div class="flex items-center gap-3 mt-1 text-xs text-muted">
         <UTooltip
-          v-if="!issue.maintainerCommented && issue.commentCount > 0"
+          v-if="issue.lastComment && user?.login && issue.lastComment.author.login !== user.login"
           :text="t('issues.needsResponse')"
         >
           <span class="inline-flex items-center gap-0.5 text-amber-500">

--- a/app/utils/issueSections.ts
+++ b/app/utils/issueSections.ts
@@ -38,8 +38,15 @@ export function categorizeIssue(issue: Issue, currentLogin: string | null): Issu
   const ageDays = (now - new Date(issue.updatedAt).getTime()) / MS_PER_DAY
   const createdDays = (now - new Date(issue.createdAt).getTime()) / MS_PER_DAY
 
-  // Maintainer-relevant only when the viewer is signed in.
-  if (currentLogin && issue.commentCount > 0 && !issue.maintainerCommented) {
+  // Maintainer-relevant only when the viewer is signed in. Uses the latest
+  // comment's author (not just "ever commented") so an issue still surfaces here
+  // when the maintainer engaged earlier and the discussion has moved on without them.
+  if (
+    currentLogin
+    && issue.commentCount > 0
+    && issue.lastComment
+    && issue.lastComment.author.login !== currentLogin
+  ) {
     return 'needs-response'
   }
   if (createdDays < FRESH_DAYS && issue.assignees.length === 0 && issue.linkedPrCount === 0) {

--- a/server/utils/issue-cache.ts
+++ b/server/utils/issue-cache.ts
@@ -15,7 +15,7 @@ const ISSUE_FIELDS = `
   labels(first: 10) { nodes { name color } }
   assignees(first: 5) { nodes { login avatarUrl } }
   milestone { title }
-  comments(first: 5) { totalCount nodes { author { login } } }
+  comments(last: 5) { totalCount nodes { author { login avatarUrl } body createdAt } }
   timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], first: 0) { totalCount }
   repository { nameWithOwner name owner { login } }
 `

--- a/shared/types/issue.ts
+++ b/shared/types/issue.ts
@@ -31,6 +31,13 @@ export interface Issue {
   linkedPrCount: number
   maintainerCommented: boolean
 
+  /** The most recent comment, if any. Used for "needs response" signals and inline previews. */
+  lastComment: {
+    author: { login: string, avatarUrl: string }
+    snippet: string
+    createdAt: string
+  } | null
+
   repository: {
     nameWithOwner: string
     name: string
@@ -53,7 +60,14 @@ export interface GraphQLIssueNode {
   labels: { nodes: Array<{ name: string, color: string }> }
   assignees: { nodes: Array<{ login: string, avatarUrl: string }> }
   milestone: { title: string } | null
-  comments: { totalCount: number, nodes: Array<{ author: { login: string } | null }> }
+  comments: {
+    totalCount: number
+    nodes: Array<{
+      author: { login: string, avatarUrl: string } | null
+      body: string
+      createdAt: string
+    }>
+  }
   timelineItems: { totalCount: number }
   repository: { nameWithOwner: string, name: string, owner: { login: string } }
 }

--- a/shared/utils/issue.ts
+++ b/shared/utils/issue.ts
@@ -1,6 +1,35 @@
 import type { GraphQLIssueNode, Issue } from '../types/issue'
 
+const SNIPPET_MAX = 120
+
+/** Strip the heaviest markdown noise so a comment body reads as plain text in a row. */
+function cleanSnippet(body: string | null | undefined, maxLen: number): string {
+  if (typeof body !== 'string' || !body) return ''
+  const stripped = body
+    .replace(/```[\s\S]*?```/g, '[code]')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '[image]')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[#*_~`>]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (stripped.length <= maxLen) return stripped
+  return stripped.slice(0, maxLen).replace(/\s+\S*$/, '') + '…'
+}
+
 export function toIssue(node: GraphQLIssueNode, maintainerLogin: string): Issue {
+  const commentNodes = node.comments.nodes
+  // GraphQL `comments(last: 5)` returns the most-recent run in chronological order,
+  // so the final element is the latest comment.
+  const lastNode = commentNodes.length ? commentNodes[commentNodes.length - 1] : null
+  const snippet = cleanSnippet(lastNode?.body, SNIPPET_MAX)
+  const lastComment = lastNode && lastNode.author && snippet
+    ? {
+        author: lastNode.author,
+        snippet,
+        createdAt: lastNode.createdAt,
+      }
+    : null
+
   return {
     id: node.id,
     number: node.number,
@@ -17,7 +46,8 @@ export function toIssue(node: GraphQLIssueNode, maintainerLogin: string): Issue 
     milestone: node.milestone?.title ?? null,
     commentCount: node.comments.totalCount,
     linkedPrCount: node.timelineItems.totalCount,
-    maintainerCommented: node.comments.nodes.some(c => c.author?.login === maintainerLogin),
+    maintainerCommented: commentNodes.some(c => c.author?.login === maintainerLogin),
+    lastComment,
     repository: {
       nameWithOwner: node.repository.nameWithOwner,
       name: node.repository.name,

--- a/shared/utils/issue.ts
+++ b/shared/utils/issue.ts
@@ -1,6 +1,6 @@
 import type { GraphQLIssueNode, Issue } from '../types/issue'
 
-const SNIPPET_MAX = 120
+const SNIPPET_MAX = 80
 
 /** Strip the heaviest markdown noise so a comment body reads as plain text in a row. */
 function cleanSnippet(body: string | null | undefined, maxLen: number): string {

--- a/test/nuxt/issueStore.test.ts
+++ b/test/nuxt/issueStore.test.ts
@@ -20,6 +20,7 @@ const mockIssue: Issue = {
   commentCount: 3,
   linkedPrCount: 1,
   maintainerCommented: false,
+  lastComment: null,
   repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
 }
 

--- a/test/unit/issueSections.test.ts
+++ b/test/unit/issueSections.test.ts
@@ -22,31 +22,38 @@ const baseIssue: Issue = {
   commentCount: 0,
   linkedPrCount: 0,
   maintainerCommented: false,
+  lastComment: null,
   repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
 }
+
+const lastCommentBy = (login: string) => ({
+  author: { login, avatarUrl: '' },
+  snippet: 'recent text',
+  createdAt: days(0),
+})
 
 describe('categorizeIssue', () => {
   it('puts closed issues into other-open as the catch-all', () => {
     expect(categorizeIssue({ ...baseIssue, state: 'CLOSED' }, 'me')).toBe('other-open')
   })
 
-  it('returns needs-response when comments exist and maintainer has not commented', () => {
-    const i = { ...baseIssue, commentCount: 3, maintainerCommented: false }
+  it('returns needs-response when the latest comment is from someone else', () => {
+    const i = { ...baseIssue, commentCount: 3, lastComment: lastCommentBy('alice') }
     expect(categorizeIssue(i, 'me')).toBe('needs-response')
   })
 
-  it('does not flag needs-response when maintainer already commented', () => {
-    const i = { ...baseIssue, commentCount: 3, maintainerCommented: true }
+  it('does not flag needs-response when the latest comment is from the viewer', () => {
+    const i = { ...baseIssue, commentCount: 3, lastComment: lastCommentBy('me') }
     expect(categorizeIssue(i, 'me')).not.toBe('needs-response')
   })
 
   it('does not flag needs-response when there are no comments', () => {
-    const i = { ...baseIssue, commentCount: 0, maintainerCommented: false }
+    const i = { ...baseIssue, commentCount: 0, lastComment: null }
     expect(categorizeIssue(i, 'me')).not.toBe('needs-response')
   })
 
   it('skips needs-response when user is not signed in', () => {
-    const i = { ...baseIssue, commentCount: 3, maintainerCommented: false }
+    const i = { ...baseIssue, commentCount: 3, lastComment: lastCommentBy('alice') }
     expect(categorizeIssue(i, null)).not.toBe('needs-response')
   })
 
@@ -81,7 +88,7 @@ describe('categorizeIssue', () => {
   })
 
   it('priority: needs-response wins over fresh-unassigned', () => {
-    const i = { ...baseIssue, createdAt: days(2), commentCount: 1, maintainerCommented: false, assignees: [], linkedPrCount: 0 }
+    const i = { ...baseIssue, createdAt: days(2), commentCount: 1, lastComment: lastCommentBy('alice'), assignees: [], linkedPrCount: 0 }
     expect(categorizeIssue(i, 'me')).toBe('needs-response')
   })
 


### PR DESCRIPTION
Closes #269. Closes #274 — needs-response now uses the last comment's author, the heuristic from #274.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue rows now show the latest comment snippet with commenter name and relative time.
  * Comment previews are cleaned for readability (code blocks/images removed, trimmed).

* **Bug Fixes / Behavior Changes**
  * "Needs response" prioritization now depends on who posted the latest comment (viewer vs. others), improving issue bucketing.

* **Tests**
  * Updated tests and fixtures to reflect the new last-comment behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/282)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->