### PR TITLE
feat(issues): magical search layer 1 — instant client-side ranking

### DIFF
--- a/app/stores/issues.ts
+++ b/app/stores/issues.ts
@@ -92,15 +92,46 @@ export const useIssueStore = defineStore('issues', () => {
   )
 
   // --- Derived ---
+
+  // Layer 1 of magical-search (#277): instant ranking over already-loaded issues
+  // so the user sees relevance signals before the server search returns.
+  const clientFuzzyResults = computed<Issue[]>(() => {
+    const q = search.value.trim()
+    if (!q) return []
+    return rankIssues(section.data.value, q, user.value?.login ?? null)
+  })
+
+  // When search is active, merge instant client matches with the server's broader
+  // recall, deduped by id, client-first so the most likely hit lands at the top.
+  const mergedSearchResults = computed<Issue[]>(() => {
+    if (!search.value.trim()) return []
+    const seen = new Set<string>()
+    const out: Issue[] = []
+    for (const issue of clientFuzzyResults.value) {
+      if (seen.has(issue.id)) continue
+      seen.add(issue.id)
+      out.push(issue)
+    }
+    for (const issue of searchResults.value) {
+      if (seen.has(issue.id)) continue
+      seen.add(issue.id)
+      out.push(issue)
+    }
+    return out
+  })
+
   const availableLabels = computed(() => {
-    const source = search.value ? searchResults.value : section.data.value
+    const source = search.value ? mergedSearchResults.value : section.data.value
     if (!source.length) return []
     const set = new Set(source.flatMap(i => i.labels.map(l => l.name)))
     return [...set].sort()
   })
 
   const sortedIssues = computed(() => {
-    const source = search.value ? searchResults.value : section.data.value
+    // Search-mode keeps the relevance order from rankIssues — sortKey doesn't
+    // override it, otherwise the magical-search ranking would be discarded.
+    if (search.value.trim()) return mergedSearchResults.value
+    const source = section.data.value
     const s = sortKey.value
     if (s === 'critical') return [...source].sort((a, b) => criticalScore(b) - criticalScore(a))
     if (s === 'newest') return [...source].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())

--- a/app/stores/issues.ts
+++ b/app/stores/issues.ts
@@ -121,7 +121,7 @@ export const useIssueStore = defineStore('issues', () => {
   })
 
   const availableLabels = computed(() => {
-    const source = search.value ? mergedSearchResults.value : section.data.value
+    const source = search.value.trim() ? mergedSearchResults.value : section.data.value
     if (!source.length) return []
     const set = new Set(source.flatMap(i => i.labels.map(l => l.name)))
     return [...set].sort()

--- a/app/utils/issueRanking.ts
+++ b/app/utils/issueRanking.ts
@@ -1,0 +1,121 @@
+import type { Issue } from '~~/shared/types/issue'
+
+/**
+ * Layer 1 of the magical-search vision (#277): instant client-side ranking
+ * over already-loaded issues. Runs synchronously on every keystroke without
+ * a network roundtrip, so users see relevant matches before the debounced
+ * server search even starts.
+ *
+ * Pure function. No side effects. Tested in test/unit/issueRanking.test.ts.
+ */
+
+const RECENCY_BOOST_LOOKBACK_DAYS = 30
+const FUZZY_MIN_QUERY_LEN = 4
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+/** Classic Wagner–Fischer Levenshtein distance. Used for typo-tolerant matching. */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  if (!a.length) return b.length
+  if (!b.length) return a.length
+
+  const prev: number[] = []
+  for (let j = 0; j <= b.length; j++) prev[j] = j
+
+  for (let i = 1; i <= a.length; i++) {
+    let curr = i
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a.charAt(i - 1) === b.charAt(j - 1) ? 0 : 1
+      const next = Math.min(curr + 1, prev[j]! + 1, prev[j - 1]! + cost)
+      prev[j - 1] = curr
+      curr = next
+    }
+    prev[b.length] = curr
+  }
+  return prev[b.length]!
+}
+
+/**
+ * Score a single issue against a normalized query. Higher = more relevant.
+ * Returns 0 when the issue is not a meaningful match.
+ */
+export function scoreIssue(issue: Issue, query: string, currentLogin: string | null, now: number): number {
+  const q = query.toLowerCase().trim()
+  if (!q) return 0
+
+  let score = 0
+  const title = issue.title.toLowerCase()
+
+  // 1. Issue-number direct match — strongest signal.
+  const numMatch = q.match(/^#?(\d+)$/)
+  if (numMatch && issue.number.toString() === numMatch[1]) {
+    return 1000
+  }
+
+  // 2. Title matching, in descending strength.
+  if (title === q) score += 250
+  else if (title.startsWith(q)) score += 150
+  else if (title.includes(q)) score += 100
+
+  // 3. Word-prefix match (any word in title starts with query).
+  const titleWords = title.split(/\s+/)
+  if (titleWords.some(w => w.startsWith(q))) score += 40
+
+  // 4. Fuzzy / typo tolerance (only for queries long enough to be meaningful).
+  if (score === 0 && q.length >= FUZZY_MIN_QUERY_LEN) {
+    const bestWordDistance = Math.min(
+      ...titleWords.map(w => levenshtein(q, w)),
+    )
+    if (bestWordDistance <= 2) score += 60
+    else if (bestWordDistance <= 3 && q.length >= 6) score += 30
+  }
+
+  // 5. Last-comment snippet match.
+  if (issue.lastComment?.snippet.toLowerCase().includes(q)) score += 25
+
+  // 6. Label match.
+  if (issue.labels.some(l => l.name.toLowerCase().includes(q))) score += 35
+
+  // 7. Author / assignee handle match.
+  if (issue.author.login.toLowerCase().includes(q)) score += 30
+  if (issue.assignees.some(a => a.login.toLowerCase().includes(q))) score += 30
+
+  // 8. Milestone match.
+  if (issue.milestone?.toLowerCase().includes(q)) score += 20
+
+  if (score === 0) return 0
+
+  // 9. Recency boost — recent activity edges out older matches at equal relevance.
+  const daysOld = (now - new Date(issue.updatedAt).getTime()) / MS_PER_DAY
+  if (daysOld < 1) score += 18
+  else if (daysOld < 7) score += 10
+  else if (daysOld < RECENCY_BOOST_LOOKBACK_DAYS) score += 4
+
+  // 10. Viewer involvement — your stuff floats up on tie.
+  if (currentLogin && issue.assignees.some(a => a.login === currentLogin)) score += 12
+  if (currentLogin && issue.author.login === currentLogin) score += 8
+
+  // 11. Discussion temperature — small bonus for active threads.
+  score += Math.min(issue.commentCount, 5)
+
+  return score
+}
+
+/**
+ * Rank a pool of issues against a query. Returns issues with score > 0,
+ * sorted by score descending. Stable on equal scores (preserves input order).
+ */
+export function rankIssues(issues: Issue[], query: string, currentLogin: string | null): Issue[] {
+  if (!query.trim()) return []
+  const now = Date.now()
+  const scored = issues
+    .map((issue, index) => ({ issue, score: scoreIssue(issue, query, currentLogin, now), index }))
+    .filter(entry => entry.score > 0)
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score
+    return a.index - b.index
+  })
+
+  return scored.map(entry => entry.issue)
+}

--- a/test/nuxt/issueStore.test.ts
+++ b/test/nuxt/issueStore.test.ts
@@ -153,15 +153,16 @@ describe('issueStore', () => {
     })
   })
 
-  it('search returns empty when no server results', async () => {
+  it('search surfaces a local match by issue number before the server responds', async () => {
     await withStore((store) => {
       store.issues = [
         { ...mockIssue, id: 'I_1', number: 42 },
         { ...mockIssue, id: 'I_2', number: 99 },
       ]
       store.search = '#99'
-      // No searchResults set — sortedIssues returns empty
-      expect(store.sortedIssues).toHaveLength(0)
+      // Layer 1 (#277): client-side ranking finds issue #99 instantly even with no server response yet.
+      expect(store.sortedIssues).toHaveLength(1)
+      expect(store.sortedIssues[0]?.id).toBe('I_2')
     })
   })
 

--- a/test/unit/issueRanking.test.ts
+++ b/test/unit/issueRanking.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import type { Issue } from '../../shared/types/issue'
+import { levenshtein, rankIssues, scoreIssue } from '../../app/utils/issueRanking'
+
+const NOW = Date.now()
+const days = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString()
+
+const baseIssue: Issue = {
+  id: 'I_1',
+  number: 42,
+  title: 'Fix login bug',
+  state: 'OPEN',
+  stateReason: null,
+  url: 'https://github.com/org/repo/issues/42',
+  createdAt: days(2),
+  updatedAt: days(2),
+  closedAt: null,
+  author: { login: 'alice', avatarUrl: '' },
+  labels: [],
+  assignees: [],
+  milestone: null,
+  commentCount: 0,
+  linkedPrCount: 0,
+  maintainerCommented: false,
+  lastComment: null,
+  repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
+}
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('login', 'login')).toBe(0)
+  })
+
+  it('counts a single substitution', () => {
+    expect(levenshtein('login', 'logon')).toBe(1)
+  })
+
+  it('counts a single deletion', () => {
+    expect(levenshtein('login', 'logn')).toBe(1)
+  })
+
+  it('counts a single insertion', () => {
+    expect(levenshtein('logn', 'login')).toBe(1)
+  })
+
+  it('handles empty strings', () => {
+    expect(levenshtein('', 'login')).toBe(5)
+    expect(levenshtein('login', '')).toBe(5)
+  })
+})
+
+describe('scoreIssue', () => {
+  it('scores 0 for unrelated query', () => {
+    expect(scoreIssue(baseIssue, 'completely-different', null, NOW)).toBe(0)
+  })
+
+  it('returns the dedicated #number-match score', () => {
+    expect(scoreIssue(baseIssue, '#42', null, NOW)).toBe(1000)
+    expect(scoreIssue(baseIssue, '42', null, NOW)).toBe(1000)
+  })
+
+  it('boosts exact title match above substring', () => {
+    const exact = scoreIssue({ ...baseIssue, title: 'login' }, 'login', null, NOW)
+    const substring = scoreIssue({ ...baseIssue, title: 'fix login bug' }, 'login', null, NOW)
+    expect(exact).toBeGreaterThan(substring)
+  })
+
+  it('boosts title-prefix match above mid-substring', () => {
+    const prefix = scoreIssue({ ...baseIssue, title: 'login fails on rate limit' }, 'login', null, NOW)
+    const middle = scoreIssue({ ...baseIssue, title: 'fix login bug' }, 'login', null, NOW)
+    expect(prefix).toBeGreaterThan(middle)
+  })
+
+  it('catches typos via fuzzy match (logn → login)', () => {
+    const fuzzy = scoreIssue(baseIssue, 'logn', null, NOW)
+    expect(fuzzy).toBeGreaterThan(0)
+  })
+
+  it('does not fuzzy-match very short queries', () => {
+    expect(scoreIssue(baseIssue, 'lg', null, NOW)).toBe(0)
+  })
+
+  it('matches on label name', () => {
+    const i = { ...baseIssue, title: 'unrelated', labels: [{ name: 'bug', color: 'ff0000' }] }
+    expect(scoreIssue(i, 'bug', null, NOW)).toBeGreaterThan(0)
+  })
+
+  it('matches on author handle', () => {
+    const i = { ...baseIssue, title: 'unrelated', author: { login: 'flo0806', avatarUrl: '' } }
+    expect(scoreIssue(i, 'flo0806', null, NOW)).toBeGreaterThan(0)
+  })
+
+  it('matches on assignee handle', () => {
+    const i = { ...baseIssue, title: 'unrelated', assignees: [{ login: 'flo0806', avatarUrl: '' }] }
+    expect(scoreIssue(i, 'flo0806', null, NOW)).toBeGreaterThan(0)
+  })
+
+  it('matches on last-comment snippet', () => {
+    const i = { ...baseIssue, title: 'unrelated', commentCount: 1, lastComment: { author: { login: 'bob', avatarUrl: '' }, snippet: 'looks good please merge', createdAt: days(0) } }
+    expect(scoreIssue(i, 'merge', null, NOW)).toBeGreaterThan(0)
+  })
+
+  it('boosts viewer-assigned issues at equal text relevance', () => {
+    const someoneElse = scoreIssue({ ...baseIssue, assignees: [{ login: 'bob', avatarUrl: '' }] }, 'login', 'me', NOW)
+    const mine = scoreIssue({ ...baseIssue, assignees: [{ login: 'me', avatarUrl: '' }] }, 'login', 'me', NOW)
+    expect(mine).toBeGreaterThan(someoneElse)
+  })
+
+  it('gives a recency boost to recently updated issues', () => {
+    const fresh = scoreIssue({ ...baseIssue, updatedAt: days(0) }, 'login', null, NOW)
+    const stale = scoreIssue({ ...baseIssue, updatedAt: days(60) }, 'login', null, NOW)
+    expect(fresh).toBeGreaterThan(stale)
+  })
+})
+
+describe('rankIssues', () => {
+  it('returns empty for empty query', () => {
+    expect(rankIssues([baseIssue], '', null)).toEqual([])
+  })
+
+  it('orders results by score descending', () => {
+    const exact: Issue = { ...baseIssue, id: 'I_exact', title: 'login' }
+    const partial: Issue = { ...baseIssue, id: 'I_partial', title: 'fix login bug' }
+    const unrelated: Issue = { ...baseIssue, id: 'I_unrelated', title: 'something else' }
+    const ranked = rankIssues([unrelated, partial, exact], 'login', null)
+    expect(ranked.map(i => i.id)).toEqual(['I_exact', 'I_partial'])
+  })
+
+  it('drops issues that score zero', () => {
+    const ranked = rankIssues([baseIssue], 'totallyunrelated', null)
+    expect(ranked).toEqual([])
+  })
+
+  it('preserves input order on equal score (stable sort)', () => {
+    const a: Issue = { ...baseIssue, id: 'A', title: 'login something' }
+    const b: Issue = { ...baseIssue, id: 'B', title: 'login something' }
+    expect(rankIssues([a, b], 'login', null).map(i => i.id)).toEqual(['A', 'B'])
+    expect(rankIssues([b, a], 'login', null).map(i => i.id)).toEqual(['B', 'A'])
+  })
+
+  it('issue-by-number wins over title-text matches', () => {
+    const byNumber: Issue = { ...baseIssue, id: 'I_42', number: 42, title: 'unrelated' }
+    const byTitle: Issue = { ...baseIssue, id: 'I_title', number: 99, title: 'something with 42 in it' }
+    const ranked = rankIssues([byTitle, byNumber], '#42', null)
+    expect(ranked[0]?.id).toBe('I_42')
+  })
+})


### PR DESCRIPTION
First slice of #277. Pure multi-signal ranking over already-loaded issues: `#number` direct, title strength, fuzzy/Levenshtein for typos, label/author/assignee/snippet, recency, viewer involvement. Merged with server search, deduped, client first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side fuzzy ranking now merges local matches with server results and surfaces local issue-number matches immediately for more relevant search results.

* **Tests**
  * Added unit tests for fuzzy matching and ranking behavior; updated search test to expect immediate local match surfacing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/284)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->