### PR TITLE
feat(issues): hint at possibly related issues during creation

### DIFF
--- a/app/components/issue/IssueSimilarHint.vue
+++ b/app/components/issue/IssueSimilarHint.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+const props = defineProps<{
+  title: string
+  repo: string
+}>()
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+const issueStore = useIssueStore()
+const { user } = useUserSession()
+
+const MIN_TITLE_LEN = 8
+const SCORE_THRESHOLD = 50
+const MAX_RESULTS = 3
+
+// Debounce so rankIssues doesn't run on every keystroke.
+const debouncedTitle = refDebounced(computed(() => props.title), 350)
+
+const similarIssues = computed(() => {
+  const title = debouncedTitle.value.trim()
+  if (title.length < MIN_TITLE_LEN) return []
+  // Only operate when issues for this repo are already loaded — no hidden fetch.
+  if (issueStore.selectedRepo !== props.repo || !issueStore.loaded) return []
+  const pool = issueStore.issues.filter(i => i.state === 'OPEN')
+  return rankIssuesScored(pool, title, user.value?.login ?? null)
+    .filter(entry => entry.score >= SCORE_THRESHOLD)
+    .slice(0, MAX_RESULTS)
+    .map(entry => entry.issue)
+})
+</script>
+
+<template>
+  <div
+    v-if="similarIssues.length"
+    class="rounded-lg border border-info/30 bg-info/5 px-3 py-2.5"
+  >
+    <div class="flex items-center gap-2 mb-1.5">
+      <UIcon
+        name="i-lucide-lightbulb"
+        class="size-4 text-info shrink-0"
+      />
+      <p class="text-sm font-medium text-default">
+        {{ t('issues.create.similarHeading') }}
+      </p>
+    </div>
+    <ul class="space-y-1">
+      <li
+        v-for="issue in similarIssues"
+        :key="issue.id"
+      >
+        <ULink
+          :to="localePath(buildWorkItemPath(repo, issue.number) ?? '/')"
+          target="_blank"
+          class="flex items-center gap-2 text-sm hover:underline min-w-0"
+        >
+          <UIcon
+            :name="getIssueStateIcon(issue.state, issue.stateReason)"
+            :class="getIssueStateColor(issue.state, issue.stateReason)"
+            class="size-4 shrink-0"
+          />
+          <span class="text-muted shrink-0">#{{ issue.number }}</span>
+          <span class="truncate">{{ issue.title }}</span>
+        </ULink>
+      </li>
+    </ul>
+    <p class="text-xs text-muted mt-2">
+      {{ t('issues.create.similarHint') }}
+    </p>
+  </div>
+</template>

--- a/app/pages/issues/new.vue
+++ b/app/pages/issues/new.vue
@@ -209,6 +209,13 @@ function submitForm(formData: Record<string, unknown>) {
         />
       </div>
 
+      <!-- Possibly related issues -->
+      <IssueSimilarHint
+        v-if="repo"
+        :title="title"
+        :repo="repo"
+      />
+
       <!-- Form fields rendered by Vorm -->
       <IssueFormRenderer
         ref="formRenderer"
@@ -274,6 +281,13 @@ function submitForm(formData: Record<string, unknown>) {
           @keydown.ctrl.enter="submitPlain"
         />
       </div>
+
+      <!-- Possibly related issues -->
+      <IssueSimilarHint
+        v-if="repo"
+        :title="title"
+        :repo="repo"
+      />
 
       <!-- Body -->
       <div class="space-y-1">

--- a/app/utils/issueRanking.ts
+++ b/app/utils/issueRanking.ts
@@ -101,11 +101,17 @@ export function scoreIssue(issue: Issue, query: string, currentLogin: string | n
   return score
 }
 
+export interface ScoredIssue {
+  issue: Issue
+  score: number
+}
+
 /**
- * Rank a pool of issues against a query. Returns issues with score > 0,
- * sorted by score descending. Stable on equal scores (preserves input order).
+ * Rank a pool of issues with their scores. Returns entries with score > 0,
+ * sorted descending. Stable on equal scores (preserves input order).
+ * Use this when the score itself is needed (e.g. similarity threshold gating).
  */
-export function rankIssues(issues: Issue[], query: string, currentLogin: string | null): Issue[] {
+export function rankIssuesScored(issues: Issue[], query: string, currentLogin: string | null): ScoredIssue[] {
   if (!query.trim()) return []
   const now = Date.now()
   const scored = issues
@@ -117,5 +123,10 @@ export function rankIssues(issues: Issue[], query: string, currentLogin: string 
     return a.index - b.index
   })
 
-  return scored.map(entry => entry.issue)
+  return scored.map(({ issue, score }) => ({ issue, score }))
+}
+
+/** Convenience: rankIssuesScored without the score wrapper. */
+export function rankIssues(issues: Issue[], query: string, currentLogin: string | null): Issue[] {
+  return rankIssuesScored(issues, query, currentLogin).map(entry => entry.issue)
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -460,7 +460,9 @@
       "chooseTemplate": "Vorlage auswählen",
       "blankIssue": "Leeres Issue",
       "blankIssueDescription": "Von Grund auf ein neues Issue erstellen.",
-      "backToTemplates": "Zurück zu Vorlagen"
+      "backToTemplates": "Zurück zu Vorlagen",
+      "similarHeading": "Möglicherweise verwandte Issues",
+      "similarHint": "Bitte vor dem Erstellen ansehen — vermeide Duplikate."
     },
     "error": {
       "fetchError": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -460,7 +460,9 @@
       "chooseTemplate": "Choose a template",
       "blankIssue": "Blank issue",
       "blankIssueDescription": "Start from scratch with an empty issue.",
-      "backToTemplates": "Back to templates"
+      "backToTemplates": "Back to templates",
+      "similarHeading": "Possibly related issues",
+      "similarHint": "Open one to check before creating — avoid duplicates."
     },
     "error": {
       "fetchError": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1389,6 +1389,12 @@
             },
             "backToTemplates": {
               "type": "string"
+            },
+            "similarHeading": {
+              "type": "string"
+            },
+            "similarHint": {
+              "type": "string"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
First slice of #280 — pre-creation duplicate hint. Title input drives a debounced `rankIssuesScored` over already-loaded issues; top 3 above the score threshold render as a banner above the form. Banner is informational, never blocks creation. Post-hoc passive detection (the bigger vision) remains open in #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Similar issues hint now appears when creating a new issue, displaying up to three potentially related existing issues to help prevent duplicates.

* **Localization**
  * Added translated strings for the similar issues feature in German and English.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->