### PR TITLE
feat(issues): author & assignee filter with avatar strip picker

### DIFF
--- a/app/components/issue/IssueFilterBar.vue
+++ b/app/components/issue/IssueFilterBar.vue
@@ -9,6 +9,29 @@ const filterChips = computed(() => [
   { key: 'hasMilestone', label: t('issues.filter.hasMilestone'), icon: 'i-lucide-milestone' },
 ])
 
+interface PersonStat {
+  login: string
+  avatarUrl: string
+  count: number
+}
+
+function tally(getPeople: (issue: { author: { login: string, avatarUrl: string }, assignees: { login: string, avatarUrl: string }[] }) => Array<{ login: string, avatarUrl: string }>): PersonStat[] {
+  const counts = new Map<string, PersonStat>()
+  for (const issue of store.issues) {
+    for (const person of getPeople(issue)) {
+      const existing = counts.get(person.login)
+      if (existing) existing.count++
+      else counts.set(person.login, { login: person.login, avatarUrl: person.avatarUrl, count: 1 })
+    }
+  }
+  return [...counts.values()].sort((a, b) => b.count - a.count)
+}
+
+// Prefer the repo-wide people pool (sampled across all issues, server-cached).
+// Fall back to in-view-derived counts if the pool fetch is still loading or empty.
+const authors = computed(() => store.repoAuthors.length ? store.repoAuthors : tally(issue => [issue.author]))
+const assignees = computed(() => store.repoAssignees.length ? store.repoAssignees : tally(issue => issue.assignees))
+
 // `/` focuses the search input — GitHub-style. Skip when typing in any input.
 onKeyStroke('/', (e) => {
   const target = e.target as HTMLElement | null
@@ -70,6 +93,17 @@ onKeyStroke('/', (e) => {
         />
         {{ chip.label }}
       </button>
+
+      <IssueUserPicker
+        filter-prefix="author"
+        :people="authors"
+        :placeholder="t('issues.filter.author')"
+      />
+      <IssueUserPicker
+        filter-prefix="assignee"
+        :people="assignees"
+        :placeholder="t('issues.filter.assignee')"
+      />
 
       <!-- Label chips (when available) -->
       <div

--- a/app/components/issue/IssueUserPicker.vue
+++ b/app/components/issue/IssueUserPicker.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+interface PickerPerson {
+  login: string
+  avatarUrl: string
+  name?: string | null
+  count: number
+}
+
+const props = defineProps<{
+  /** Filter prefix — `author` or `assignee`. */
+  filterPrefix: 'author' | 'assignee'
+  /** People sourced from currently-loaded issues, sorted by frequency desc. */
+  people: PickerPerson[]
+  /** Visible label when no selection is active. */
+  placeholder: string
+}>()
+
+const store = useIssueStore()
+const open = ref(false)
+
+const currentValue = computed(() => {
+  return store.activeFilters
+    .find(f => f.startsWith(`${props.filterPrefix}:`))
+    ?.slice(props.filterPrefix.length + 1) ?? null
+})
+
+const currentPerson = computed(() => {
+  if (!currentValue.value) return null
+  return props.people.find(p => p.login === currentValue.value) ?? {
+    // Person isn't in the currently-loaded pool (e.g. filter set from a previous repo);
+    // render with a placeholder avatar derived from the GitHub identicon endpoint.
+    login: currentValue.value,
+    avatarUrl: `https://github.com/${currentValue.value}.png?size=40`,
+    count: 0,
+  }
+})
+
+function pick(login: string) {
+  if (currentValue.value === login) {
+    store.setUniqueFilter(props.filterPrefix, null)
+  }
+  else {
+    store.setUniqueFilter(props.filterPrefix, login)
+  }
+  open.value = false
+}
+
+function clear(event: Event) {
+  event.stopPropagation()
+  store.setUniqueFilter(props.filterPrefix, null)
+}
+</script>
+
+<template>
+  <UPopover v-model:open="open">
+    <button
+      type="button"
+      class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs font-medium transition-colors cursor-pointer"
+      :class="currentValue
+        ? 'bg-primary text-inverted'
+        : 'bg-muted text-toned hover:bg-accented'"
+    >
+      <UAvatar
+        v-if="currentPerson"
+        :src="currentPerson.avatarUrl"
+        :alt="currentPerson.login"
+        size="3xs"
+      />
+      <UIcon
+        v-else
+        :name="filterPrefix === 'author' ? 'i-lucide-pencil-line' : 'i-lucide-user-check'"
+        class="size-3.5"
+      />
+      <span>{{ currentPerson ? `@${currentPerson.login}` : placeholder }}</span>
+      <UIcon
+        v-if="currentValue"
+        name="i-lucide-x"
+        class="size-3 hover:opacity-80"
+        @click="clear"
+      />
+    </button>
+
+    <template #content>
+      <div class="w-64 max-h-80 overflow-y-auto p-2">
+        <p
+          v-if="!people.length"
+          class="text-xs text-muted px-1 py-2 text-center"
+        >
+          {{ $t('issues.filter.noPeople') }}
+        </p>
+        <div
+          v-else
+          class="grid grid-cols-1 gap-0.5"
+        >
+          <button
+            v-for="person in people"
+            :key="person.login"
+            type="button"
+            class="flex items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-elevated transition-colors cursor-pointer text-left min-w-0"
+            :class="currentValue === person.login ? 'bg-elevated' : ''"
+            @click="pick(person.login)"
+          >
+            <UAvatar
+              :src="person.avatarUrl"
+              :alt="person.login"
+              size="2xs"
+            />
+            <span class="flex-1 min-w-0 truncate">
+              <span>@{{ person.login }}</span>
+              <span
+                v-if="person.name"
+                class="ml-1.5 text-xs text-muted"
+              >{{ person.name }}</span>
+            </span>
+            <UIcon
+              v-if="currentValue === person.login"
+              name="i-lucide-check"
+              class="size-4 text-primary shrink-0"
+            />
+          </button>
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/app/stores/issues.ts
+++ b/app/stores/issues.ts
@@ -30,6 +30,12 @@ export const useIssueStore = defineStore('issues', () => {
   const openCount = ref<number | null>(null)
   const closedCount = ref<number | null>(null)
 
+  // Repo-wide people pool (sampled across recent issues, server-cached).
+  // Used by the author/assignee filter pickers — broader than the first 20 loaded issues.
+  interface RepoPerson { login: string, avatarUrl: string, name?: string | null, count: number }
+  const repoAuthors = ref<RepoPerson[]>([])
+  const repoAssignees = ref<RepoPerson[]>([])
+
   const EXCLUSIVE_FILTERS = ['assignedToMe', 'unassigned']
 
   const hasActiveFilters = computed(() =>
@@ -48,12 +54,32 @@ export const useIssueStore = defineStore('issues', () => {
       activeFilters.value = current.filter(f => f !== key)
     }
     else {
-      // Mutually exclusive: enabling one disables its pair
+      // Mutually exclusive: enabling assignedToMe/unassigned disables the pair
+      // AND any specific assignee:* picker.
       if (EXCLUSIVE_FILTERS.includes(key)) {
-        current = current.filter(f => !EXCLUSIVE_FILTERS.includes(f))
+        current = current.filter(f =>
+          !EXCLUSIVE_FILTERS.includes(f) && !f.startsWith('assignee:'),
+        )
       }
       activeFilters.value = [...current, key]
     }
+    refetchAfterFilterChange()
+  }
+
+  /**
+   * Set a single-value filter under a given prefix (e.g. `author`, `assignee`).
+   * Pass `value === null` to clear it. Replaces any existing filter for that prefix.
+   * For `assignee`, also clears the assignedToMe/unassigned pair.
+   */
+  function setUniqueFilter(prefix: 'author' | 'assignee', value: string | null) {
+    let next = activeFilters.value.filter(f => !f.startsWith(`${prefix}:`))
+    if (prefix === 'assignee') {
+      next = next.filter(f => !EXCLUSIVE_FILTERS.includes(f))
+    }
+    if (value) next = [...next, `${prefix}:${value}`]
+    if (next.length === activeFilters.value.length
+      && next.every((v, i) => v === activeFilters.value[i])) return
+    activeFilters.value = next
     refetchAfterFilterChange()
   }
 
@@ -81,6 +107,10 @@ export const useIssueStore = defineStore('issues', () => {
     if (activeFilters.value.includes('hasMilestone')) p.milestone = '*'
     const labels = activeFilters.value.filter(f => f.startsWith('label:')).map(f => f.slice(6))
     if (labels.length) p.label = labels.join(',')
+    const author = activeFilters.value.find(f => f.startsWith('author:'))?.slice(7)
+    if (author) p.author = author
+    const assignee = activeFilters.value.find(f => f.startsWith('assignee:'))?.slice(9)
+    if (assignee) p.assignee = assignee
     return p
   }
 
@@ -145,8 +175,15 @@ export const useIssueStore = defineStore('issues', () => {
   const issuesBySection = computed(() => {
     const buckets = createEmptyIssueBuckets()
     const login = user.value?.login ?? null
-    for (const issue of sortedIssues.value) {
+    for (const issue of section.data.value) {
       buckets[categorizeIssue(issue, login)].push(issue)
+    }
+    // Sub-order within each bucket: newest-first by *substantial* activity.
+    // Prefer the latest comment timestamp over `updatedAt` so label-only edits
+    // (often bot-triggered) don't bubble dead threads to the top.
+    const activityAt = (issue: Issue) => new Date(issue.lastComment?.createdAt ?? issue.updatedAt).getTime()
+    for (const key of Object.keys(buckets) as Array<keyof typeof buckets>) {
+      buckets[key].sort((a, b) => activityAt(b) - activityAt(a))
     }
     return buckets
   })
@@ -202,6 +239,10 @@ export const useIssueStore = defineStore('issues', () => {
       if (activeFilters.value.includes('hasMilestone')) params.milestone = '*'
       const labels = activeFilters.value.filter(f => f.startsWith('label:')).map(f => f.slice(6))
       if (labels.length) params.label = labels.join(',')
+      const author = activeFilters.value.find(f => f.startsWith('author:'))?.slice(7)
+      if (author) params.author = author
+      const assignee = activeFilters.value.find(f => f.startsWith('assignee:'))?.slice(9)
+      if (assignee) params.assignee = assignee
 
       const results = await apiFetch<Issue[]>('/api/issues/search', { params })
       if (requestId !== searchRequestId) return
@@ -227,6 +268,24 @@ export const useIssueStore = defineStore('issues', () => {
     searchDebounceTimer = setTimeout(() => searchIssues(q), 300)
   })
 
+  async function fetchPeoplePool() {
+    if (!selectedRepo.value) return
+    const [owner, name] = selectedRepo.value.split('/')
+    if (!owner || !name) return
+    try {
+      const data = await apiFetch<{ authors: RepoPerson[], assignees: RepoPerson[] }>(
+        `/api/repository/${owner}/${name}/issue-people`,
+      )
+      repoAuthors.value = data.authors
+      repoAssignees.value = data.assignees
+    }
+    catch {
+      // Best-effort — FilterBar falls back to the in-view derived pool.
+      repoAuthors.value = []
+      repoAssignees.value = []
+    }
+  }
+
   async function selectRepo(repo: string) {
     if (repo === selectedRepo.value && loaded.value) return
     selectedRepo.value = repo
@@ -235,7 +294,9 @@ export const useIssueStore = defineStore('issues', () => {
     searchResults.value = []
     openCount.value = null
     closedCount.value = null
-    await fetchIssues()
+    repoAuthors.value = []
+    repoAssignees.value = []
+    await Promise.all([fetchIssues(), fetchPeoplePool()])
   }
 
   function updateIssue(repo: string, number: number, patch: Partial<Issue>) {
@@ -268,7 +329,10 @@ export const useIssueStore = defineStore('issues', () => {
     activeFilters,
     hasActiveFilters,
     toggleFilter,
+    setUniqueFilter,
     clearFilters,
+    repoAuthors,
+    repoAssignees,
     openCount,
     closedCount,
     totalCount: section.totalCount,

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -369,6 +369,9 @@
       "assignedToMe": "Mir zugewiesen",
       "unassigned": "Nicht zugewiesen",
       "hasMilestone": "Meilenstein",
+      "author": "Von…",
+      "assignee": "Zugewiesen…",
+      "noPeople": "Noch keine Personen in dieser Ansicht.",
       "clear": "Filter zurücksetzen"
     },
     "filtered": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -369,6 +369,9 @@
       "assignedToMe": "Assigned to me",
       "unassigned": "Unassigned",
       "hasMilestone": "Milestone",
+      "author": "From…",
+      "assignee": "Assigned…",
+      "noPeople": "No people in this view yet.",
       "clear": "Clear filters"
     },
     "filtered": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1114,6 +1114,15 @@
             "hasMilestone": {
               "type": "string"
             },
+            "author": {
+              "type": "string"
+            },
+            "assignee": {
+              "type": "string"
+            },
+            "noPeople": {
+              "type": "string"
+            },
             "clear": {
               "type": "string"
             }

--- a/server/api/issues/index.get.ts
+++ b/server/api/issues/index.get.ts
@@ -31,7 +31,7 @@ interface MinimalSearchResult {
 
 export default defineEventHandler(async (event): Promise<PaginatedResponse<Issue>> => {
   const { token, login } = await getSessionToken(event)
-  const { state = 'open', repo, first = '20', after, assignedToMe, unassigned, label, milestone } = getQuery<{
+  const { state = 'open', repo, first = '20', after, assignedToMe, unassigned, label, milestone, author, assignee } = getQuery<{
     state?: string
     repo?: string
     first?: string
@@ -40,6 +40,8 @@ export default defineEventHandler(async (event): Promise<PaginatedResponse<Issue
     unassigned?: string
     label?: string
     milestone?: string
+    author?: string
+    assignee?: string
   }>(event)
 
   if (!repo || !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
@@ -74,6 +76,10 @@ export default defineEventHandler(async (event): Promise<PaginatedResponse<Issue
       if (l.trim()) query += ` label:"${escapeGitHubQuery(l.trim())}"`
     }
   }
+  // GitHub login regex: alphanumeric + hyphens (no leading/trailing/double hyphen).
+  const LOGIN_RE = /^(?!.*--)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/
+  if (author && LOGIN_RE.test(String(author))) query += ` author:${author}`
+  if (assignee && LOGIN_RE.test(String(assignee))) query += ` assignee:${assignee}`
 
   // 1. Lightweight search — only id, number, updatedAt
   const data = await githubGraphQL<MinimalSearchResult>(token, MINIMAL_SEARCH_QUERY, {

--- a/server/api/issues/search.get.ts
+++ b/server/api/issues/search.get.ts
@@ -27,7 +27,7 @@ function escapeGitHubQuery(value: string): string {
 
 export default defineEventHandler(async (event): Promise<Issue[]> => {
   const { token, login } = await getSessionToken(event)
-  const { repo, state = 'open', q, assignedToMe, unassigned, label, milestone } = getQuery<{
+  const { repo, state = 'open', q, assignedToMe, unassigned, label, milestone, author, assignee } = getQuery<{
     repo?: string
     state?: string
     q?: string
@@ -35,6 +35,8 @@ export default defineEventHandler(async (event): Promise<Issue[]> => {
     unassigned?: string
     label?: string
     milestone?: string
+    author?: string
+    assignee?: string
   }>(event)
 
   if (!repo || !q || !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
@@ -64,6 +66,9 @@ export default defineEventHandler(async (event): Promise<Issue[]> => {
       if (l.trim()) query += ` label:"${escapeGitHubQuery(l.trim())}"`
     }
   }
+  const LOGIN_RE = /^(?!.*--)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/
+  if (author && LOGIN_RE.test(String(author))) query += ` author:${author}`
+  if (assignee && LOGIN_RE.test(String(assignee))) query += ` assignee:${assignee}`
 
   const data = await githubGraphQL<MinimalSearchResult>(token, MINIMAL_SEARCH_QUERY, {
     query,

--- a/server/api/repository/[owner]/[repo]/issue-people.get.ts
+++ b/server/api/repository/[owner]/[repo]/issue-people.get.ts
@@ -1,0 +1,92 @@
+interface Person {
+  login: string
+  avatarUrl: string
+  name: string | null
+  count: number
+}
+
+interface IssuePeopleResponse {
+  authors: Person[]
+  assignees: Person[]
+}
+
+const PEOPLE_QUERY = `
+query($owner: String!, $repo: String!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    issues(first: 100, after: $cursor, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        author { ... on User { login avatarUrl name } ... on Bot { login avatarUrl } }
+        assignees(first: 10) { nodes { login avatarUrl name } }
+      }
+    }
+  }
+}
+`
+
+interface PeopleQueryResponse {
+  repository: {
+    issues: {
+      pageInfo: { hasNextPage: boolean, endCursor: string | null }
+      nodes: Array<{
+        author: { login: string, avatarUrl: string, name?: string | null } | null
+        assignees: { nodes: Array<{ login: string, avatarUrl: string, name?: string | null }> }
+      }>
+    } | null
+  } | null
+}
+
+const MAX_PAGES = 5 // up to 500 issues sampled — enough to surface the active community
+
+const fetchIssuePeople = defineCachedFunction(
+  async (token: string, _login: string, userId: number, owner: string, repo: string): Promise<IssuePeopleResponse> => {
+    const authors = new Map<string, Person>()
+    const assignees = new Map<string, Person>()
+    let cursor: string | null = null
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const data: PeopleQueryResponse = await githubGraphQL(
+        token,
+        PEOPLE_QUERY,
+        { owner, repo, cursor },
+        userId,
+      )
+      const issues = data.repository?.issues
+      if (!issues) break
+
+      for (const node of issues.nodes) {
+        if (node.author?.login) {
+          const existing = authors.get(node.author.login)
+          if (existing) existing.count++
+          else authors.set(node.author.login, { login: node.author.login, avatarUrl: node.author.avatarUrl, name: node.author.name ?? null, count: 1 })
+        }
+        for (const a of node.assignees.nodes) {
+          const existing = assignees.get(a.login)
+          if (existing) existing.count++
+          else assignees.set(a.login, { login: a.login, avatarUrl: a.avatarUrl, name: a.name ?? null, count: 1 })
+        }
+      }
+
+      if (!issues.pageInfo.hasNextPage) break
+      cursor = issues.pageInfo.endCursor
+    }
+
+    const sortByCount = (a: Person, b: Person) => b.count - a.count
+
+    return {
+      authors: [...authors.values()].sort(sortByCount),
+      assignees: [...assignees.values()].sort(sortByCount),
+    }
+  },
+  {
+    name: 'issue-people',
+    getKey: (_token: string, login: string, _userId: number, owner: string, repo: string) => `${login}:${owner}/${repo}`,
+    maxAge: 60 * 30,
+  },
+)
+
+export default defineEventHandler(async (event): Promise<IssuePeopleResponse> => {
+  const { token, login, userId } = await getSessionToken(event)
+  const { owner, repo } = getRepoParams(event)
+  return fetchIssuePeople(token, login, userId, owner, repo)
+})

--- a/test/nuxt/issueStore.test.ts
+++ b/test/nuxt/issueStore.test.ts
@@ -279,5 +279,45 @@ describe('issueStore', () => {
         expect(store.hasActiveFilters).toBe(false)
       })
     })
+
+    it('setUniqueFilter replaces any previous value for the same prefix', async () => {
+      await withStore(async (store) => {
+        await store.selectRepo('org/repo')
+        store.setUniqueFilter('author', 'alice')
+        store.setUniqueFilter('author', 'bob')
+        const authors = store.activeFilters.filter(f => f.startsWith('author:'))
+        expect(authors).toEqual(['author:bob'])
+      })
+    })
+
+    it('setUniqueFilter with null clears the filter', async () => {
+      await withStore(async (store) => {
+        await store.selectRepo('org/repo')
+        store.setUniqueFilter('author', 'alice')
+        store.setUniqueFilter('author', null)
+        expect(store.activeFilters.some(f => f.startsWith('author:'))).toBe(false)
+      })
+    })
+
+    it('setUniqueFilter("assignee", X) clears assignedToMe and unassigned', async () => {
+      await withStore(async (store) => {
+        await store.selectRepo('org/repo')
+        store.activeFilters = ['assignedToMe', 'hasMilestone']
+        store.setUniqueFilter('assignee', 'bob')
+        expect(store.activeFilters).toContain('assignee:bob')
+        expect(store.activeFilters).not.toContain('assignedToMe')
+        expect(store.activeFilters).toContain('hasMilestone')
+      })
+    })
+
+    it('toggleFilter("assignedToMe") clears any specific assignee:* filter', async () => {
+      await withStore(async (store) => {
+        await store.selectRepo('org/repo')
+        store.activeFilters = ['assignee:bob']
+        store.toggleFilter('assignedToMe')
+        expect(store.activeFilters).toContain('assignedToMe')
+        expect(store.activeFilters.some(f => f.startsWith('assignee:'))).toBe(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #285. Single-select chips for author and assignee filters, avatar-strip popover sourced from a server-aggregated repo-wide people pool (sampled across recent issues, cached). Bonus: section sub-sort now uses last-comment timestamp instead of `updatedAt` so label-only edits don't bubble dead threads. Cleaner version tracked in #287.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering by issue author and assignee to streamline issue discovery.
  * Introduced people picker UI for selecting specific authors and assignees.
  * Improved issue sorting with activity-based ordering (newest comments/updates first).
  * Server-side caching of author and assignee pools for performance.

* **Tests**
  * Added test coverage for filter manipulation and exclusive filter behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->