### PR TITLE
feat(issues): mobile-responsive page and rows

### DIFF
--- a/app/components/issue/IssueFilterBar.vue
+++ b/app/components/issue/IssueFilterBar.vue
@@ -60,7 +60,7 @@ onKeyStroke('/', (e) => {
         >
         <kbd
           v-if="!store.search"
-          class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted bg-default px-1.5 py-0.5 rounded border border-default pointer-events-none"
+          class="hidden sm:block absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted bg-default px-1.5 py-0.5 rounded border border-default pointer-events-none"
         >/</kbd>
       </div>
       <UButton

--- a/app/components/issue/IssueRow.vue
+++ b/app/components/issue/IssueRow.vue
@@ -72,7 +72,7 @@ function navigate() {
           :repo="issue.repository.nameWithOwner"
           :number="issue.number"
           :labels="localLabels"
-          add-button-class="opacity-100 sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-focus-within:pointer-events-auto transition-opacity duration-150"
+          add-button-class="opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto transition-opacity duration-150"
           @added="onLabelAdded"
           @removed="onLabelRemoved"
         />

--- a/app/components/issue/IssueRow.vue
+++ b/app/components/issue/IssueRow.vue
@@ -46,7 +46,7 @@ function navigate() {
   <div
     role="link"
     tabindex="0"
-    class="group flex items-start gap-3 px-4 py-3 hover:bg-elevated transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-elevated"
+    class="group flex items-start gap-2 sm:gap-3 px-2 py-2.5 sm:px-4 sm:py-3 hover:bg-elevated transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-elevated"
     @click="navigate"
     @keydown.enter.self="navigate"
     @keydown.space.self.prevent="navigate"
@@ -62,7 +62,7 @@ function navigate() {
     <div class="min-w-0 flex-1">
       <!-- Row 1: Title + labels -->
       <div class="flex items-center gap-2 flex-wrap">
-        <span class="font-medium text-highlighted hover:underline">
+        <span class="font-medium text-highlighted hover:underline text-sm sm:text-base">
           <UiHighlightedText
             :text="issue.title"
             :query="issueStore.search"
@@ -72,27 +72,28 @@ function navigate() {
           :repo="issue.repository.nameWithOwner"
           :number="issue.number"
           :labels="localLabels"
-          add-button-class="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity duration-150"
+          add-button-class="opacity-100 sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-focus-within:pointer-events-auto transition-opacity duration-150"
           @added="onLabelAdded"
           @removed="onLabelRemoved"
         />
       </div>
 
-      <!-- Row 2: Last-comment quote (when available) -->
+      <!-- Row 2: Last-comment quote (when available). On narrow screens
+           the attribution stacks under the quote so the snippet keeps room. -->
       <div
         v-if="issue.lastComment"
-        class="flex items-baseline gap-2 mt-1 text-xs min-w-0"
+        class="flex flex-col sm:flex-row sm:items-baseline sm:gap-2 mt-1 text-xs min-w-0"
       >
         <span
-          class="flex-1 min-w-0 italic text-muted/80 border-l-2 border-primary/30 pl-2 truncate"
+          class="flex-1 min-w-0 italic text-muted/80 border-l-2 border-primary/30 pl-2 line-clamp-2 sm:line-clamp-none sm:truncate"
         >&ldquo;{{ issue.lastComment.snippet }}&rdquo;</span>
-        <span class="shrink-0 text-muted/60 whitespace-nowrap">
+        <span class="shrink-0 text-muted/60 whitespace-nowrap pl-2 sm:pl-0">
           {{ issue.lastComment.author.login }} · {{ lastCommentAgo }}
         </span>
       </div>
 
-      <!-- Row 3: Meta -->
-      <div class="flex items-center gap-3 mt-1 text-xs text-muted">
+      <!-- Row 3: Meta — wraps on narrow screens so nothing gets clipped -->
+      <div class="flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3 sm:gap-y-1 mt-1 text-xs text-muted">
         <UTooltip
           v-if="issue.lastComment && user?.login && issue.lastComment.author.login !== user.login"
           :text="t('issues.needsResponse')"
@@ -165,7 +166,7 @@ function navigate() {
 
     <!-- Right side: Assign + Assignees -->
     <div class="flex items-center gap-1 shrink-0">
-      <span class="opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity duration-150">
+      <span class="opacity-100 sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-focus-within:pointer-events-auto transition-opacity duration-150">
         <UiAssignButton
           :repo="repo"
           :number="issue.number"

--- a/app/pages/issues/index.vue
+++ b/app/pages/issues/index.vue
@@ -38,7 +38,7 @@ async function setFilter(state: 'open' | 'closed') {
 </script>
 
 <template>
-  <div class="p-4 space-y-4">
+  <div class="p-2 sm:p-4 space-y-3 sm:space-y-4">
     <!-- Repo selector -->
     <div class="flex items-center gap-2">
       <IssueRepoSelect />
@@ -82,7 +82,7 @@ async function setFilter(state: 'open' | 'closed') {
       <!-- Loaded -->
       <template v-else-if="store.loaded">
         <!-- State tabs + Create -->
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
           <IssueStateTab
             :label="t('issues.open')"
             icon-key="i-lucide-circle-dot"


### PR DESCRIPTION
Closes #283. Tightens the issues page for narrow viewports: smaller page and card padding, wrapping meta row, two-line snippet on mobile, hover-revealed actions become always-visible without hover, `/` keyboard hint hidden on touch, last-comment attribution stacks under the quote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined responsive layouts and spacing for improved mobile experience
  * Enhanced typography with responsive font sizing for better readability
  * Search hint now only shown when the search field is empty for a cleaner interface
  * Updated row and control behaviors for touch vs hover devices, keeping important actions accessible on small screens
  * Improved comment preview truncation and wrapping for clearer, more consistent display

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/289)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->