### PR TITLE
feat(issues): substantial-activity timestamp for section sort

### DIFF
--- a/app/components/issue/IssueRow.vue
+++ b/app/components/issue/IssueRow.vue
@@ -166,7 +166,7 @@ function navigate() {
 
     <!-- Right side: Assign + Assignees -->
     <div class="flex items-center gap-1 shrink-0">
-      <span class="opacity-100 sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-focus-within:pointer-events-auto transition-opacity duration-150">
+      <span class="opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto transition-opacity duration-150">
         <UiAssignButton
           :repo="repo"
           :number="issue.number"

--- a/app/stores/issues.ts
+++ b/app/stores/issues.ts
@@ -179,9 +179,9 @@ export const useIssueStore = defineStore('issues', () => {
       buckets[categorizeIssue(issue, login)].push(issue)
     }
     // Sub-order within each bucket: newest-first by *substantial* activity.
-    // Prefer the latest comment timestamp over `updatedAt` so label-only edits
-    // (often bot-triggered) don't bubble dead threads to the top.
-    const activityAt = (issue: Issue) => new Date(issue.lastComment?.createdAt ?? issue.updatedAt).getTime()
+    // `lastSubstantialActivityAt` skips label and milestone-only edits so
+    // bot-driven re-tagging doesn't bubble dead threads to the top.
+    const activityAt = (issue: Issue) => new Date(issue.lastSubstantialActivityAt ?? issue.updatedAt).getTime()
     for (const key of Object.keys(buckets) as Array<keyof typeof buckets>) {
       buckets[key].sort((a, b) => activityAt(b) - activityAt(a))
     }

--- a/server/utils/issue-cache.ts
+++ b/server/utils/issue-cache.ts
@@ -16,7 +16,30 @@ const ISSUE_FIELDS = `
   assignees(first: 5) { nodes { login avatarUrl } }
   milestone { title }
   comments(last: 5) { totalCount nodes { author { login avatarUrl } body createdAt } }
-  timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], first: 0) { totalCount }
+  linkedPrs: timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], first: 0) { totalCount }
+  substantialActivity: timelineItems(
+    itemTypes: [
+      ISSUE_COMMENT,
+      CLOSED_EVENT,
+      REOPENED_EVENT,
+      ASSIGNED_EVENT,
+      UNASSIGNED_EVENT,
+      CROSS_REFERENCED_EVENT,
+      REFERENCED_EVENT
+    ],
+    last: 1
+  ) {
+    nodes {
+      __typename
+      ... on IssueComment { createdAt }
+      ... on ClosedEvent { createdAt }
+      ... on ReopenedEvent { createdAt }
+      ... on AssignedEvent { createdAt }
+      ... on UnassignedEvent { createdAt }
+      ... on CrossReferencedEvent { createdAt }
+      ... on ReferencedEvent { createdAt }
+    }
+  }
   repository { nameWithOwner name owner { login } }
 `
 

--- a/shared/types/issue.ts
+++ b/shared/types/issue.ts
@@ -38,6 +38,15 @@ export interface Issue {
     createdAt: string
   } | null
 
+  /**
+   * Timestamp of the latest substantial timeline event (comment, state change,
+   * assignment, cross-reference, etc.). Excludes label and milestone changes
+   * so bot-driven re-tagging doesn't bubble dead threads to the top.
+   * Falls back to `null` when no such event exists — sort consumers should use
+   * `lastSubstantialActivityAt ?? updatedAt`.
+   */
+  lastSubstantialActivityAt: string | null
+
   repository: {
     nameWithOwner: string
     name: string
@@ -68,7 +77,17 @@ export interface GraphQLIssueNode {
       createdAt: string
     }>
   }
-  timelineItems: { totalCount: number }
+  /** Aliased timelineItems for linked PR count (cross-references). */
+  linkedPrs?: { totalCount: number }
+  /** Aliased timelineItems for the latest substantial activity event. */
+  substantialActivity?: {
+    nodes: Array<{
+      __typename: string
+      createdAt: string
+    }>
+  }
+  /** Legacy alias kept for cached entries written before the rename. */
+  timelineItems?: { totalCount: number }
   repository: { nameWithOwner: string, name: string, owner: { login: string } }
 }
 

--- a/shared/utils/issue.ts
+++ b/shared/utils/issue.ts
@@ -30,6 +30,16 @@ export function toIssue(node: GraphQLIssueNode, maintainerLogin: string): Issue 
       }
     : null
 
+  // `linkedPrs` is the aliased timelineItems(CROSS_REFERENCED_EVENT) count.
+  // Fall back to the pre-alias `timelineItems` shape for cache entries written
+  // before the rename — defensive, lets older cached nodes still render.
+  const linkedPrCount = node.linkedPrs?.totalCount ?? node.timelineItems?.totalCount ?? 0
+
+  // Latest substantial activity event timestamp (excludes label/milestone-only edits).
+  const substantialEvents = node.substantialActivity?.nodes ?? []
+  const latestEvent = substantialEvents[substantialEvents.length - 1]
+  const lastSubstantialActivityAt = latestEvent?.createdAt ?? null
+
   return {
     id: node.id,
     number: node.number,
@@ -45,9 +55,10 @@ export function toIssue(node: GraphQLIssueNode, maintainerLogin: string): Issue 
     assignees: node.assignees.nodes,
     milestone: node.milestone?.title ?? null,
     commentCount: node.comments.totalCount,
-    linkedPrCount: node.timelineItems.totalCount,
+    linkedPrCount,
     maintainerCommented: commentNodes.some(c => c.author?.login === maintainerLogin),
     lastComment,
+    lastSubstantialActivityAt,
     repository: {
       nameWithOwner: node.repository.nameWithOwner,
       name: node.repository.name,

--- a/test/nuxt/issueStore.test.ts
+++ b/test/nuxt/issueStore.test.ts
@@ -21,6 +21,7 @@ const mockIssue: Issue = {
   linkedPrCount: 1,
   maintainerCommented: false,
   lastComment: null,
+  lastSubstantialActivityAt: null,
   repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
 }
 

--- a/test/unit/issueRanking.test.ts
+++ b/test/unit/issueRanking.test.ts
@@ -23,6 +23,7 @@ const baseIssue: Issue = {
   linkedPrCount: 0,
   maintainerCommented: false,
   lastComment: null,
+  lastSubstantialActivityAt: null,
   repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
 }
 

--- a/test/unit/issueSections.test.ts
+++ b/test/unit/issueSections.test.ts
@@ -23,6 +23,7 @@ const baseIssue: Issue = {
   linkedPrCount: 0,
   maintainerCommented: false,
   lastComment: null,
+  lastSubstantialActivityAt: null,
   repository: { nameWithOwner: 'org/repo', name: 'repo', owner: 'org' },
 }
 


### PR DESCRIPTION
Closes #287. Section sub-sort now uses `lastSubstantialActivityAt` from a filtered `timelineItems` query (comments, state changes, assignments, references) instead of falling back to `updatedAt`. Label-only and milestone-only edits no longer bubble dead threads to the top. Drops the `lastComment.createdAt` quick-fix from #285.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Issues are now ranked by substantial activity metrics, providing more meaningful prioritization in categorized lists.
  * Activity tracking enhanced to accurately capture linked pull requests and significant timeline events.

* **Style**
  * Assign button visibility and pointer interactions now intelligently adapt based on device hover support capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/290)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->