### PR TITLE
feat: bookmarks for issues, PRs, repos

### DIFF
--- a/app/components/issue/IssueRow.vue
+++ b/app/components/issue/IssueRow.vue
@@ -164,8 +164,16 @@ function navigate() {
       </div>
     </div>
 
-    <!-- Right side: Assign + Assignees -->
+    <!-- Right side: Bookmark + Assign + Assignees -->
     <div class="flex items-center gap-1 shrink-0">
+      <UiBookmarkButton
+        type="issue"
+        :repo="repo"
+        :number="issue.number"
+        :title="issue.title"
+        :url="localePath(buildWorkItemPath(repo, issue.number)!)"
+        :avatar-url="issue.author.avatarUrl"
+      />
       <span class="opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto transition-opacity duration-150">
         <UiAssignButton
           :repo="repo"

--- a/app/components/ui/BookmarkButton.vue
+++ b/app/components/ui/BookmarkButton.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+const props = defineProps<{
+  type: BookmarkType
+  /** `owner/name` for issue/pr/repo. */
+  repo: string
+  /** Required for issue/pr; ignored for repo. */
+  number?: number
+  title: string
+  /** Internal app path to navigate when the bookmark is opened later. */
+  url: string
+  avatarUrl?: string
+}>()
+
+const { t } = useI18n()
+const store = useBookmarkStore()
+store.loadIfNeeded()
+
+const id = computed(() => bookmarkId(props.type, props.repo, props.number))
+const active = computed(() => store.isBookmarked(id.value))
+
+function toggle(event: Event) {
+  event.stopPropagation()
+  event.preventDefault()
+  store.toggleBookmark({
+    type: props.type,
+    id: id.value,
+    title: props.title,
+    repo: props.repo,
+    number: props.number,
+    url: props.url,
+    avatarUrl: props.avatarUrl,
+  })
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="active"
+    :aria-label="active ? t('bookmark.remove') : t('bookmark.add')"
+    :title="active ? t('bookmark.remove') : t('bookmark.add')"
+    class="inline-flex items-center justify-center size-7 rounded-md transition-colors cursor-pointer"
+    :class="active
+      ? 'text-warning hover:bg-warning/10'
+      : 'text-muted hover:text-highlighted hover:bg-elevated'"
+    @click="toggle"
+  >
+    <UIcon
+      :name="active ? 'i-lucide-bookmark-check' : 'i-lucide-bookmark'"
+      class="size-4"
+    />
+  </button>
+</template>

--- a/app/components/ui/BookmarkButton.vue
+++ b/app/components/ui/BookmarkButton.vue
@@ -15,7 +15,11 @@ const { t } = useI18n()
 const store = useBookmarkStore()
 store.loadIfNeeded()
 
-const id = computed(() => bookmarkId(props.type, props.repo, props.number))
+const id = computed(() =>
+  props.type === 'repo'
+    ? bookmarkId('repo', props.repo)
+    : bookmarkId(props.type, props.repo, props.number!),
+)
 const active = computed(() => store.isBookmarked(id.value))
 
 function toggle(event: Event) {

--- a/app/components/ui/SideBar.vue
+++ b/app/components/ui/SideBar.vue
@@ -171,6 +171,12 @@ const mainItems = computed<NavigationMenuItem[]>(() => [
     disabled: !loggedIn.value,
   },
   {
+    label: t('nav.bookmarks'),
+    icon: 'i-lucide-bookmark',
+    to: localePath('/bookmarks'),
+    disabled: !loggedIn.value,
+  },
+  {
     label: t('nav.settings'),
     icon: 'i-lucide-settings',
     to: localePath('/settings'),

--- a/app/pages/bookmarks.vue
+++ b/app/pages/bookmarks.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+  titleKey: 'bookmark.title',
+})
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+const store = useBookmarkStore()
+store.loadIfNeeded()
+
+const sections = computed(() => [
+  { key: 'issue' as const, label: t('bookmark.section.issues'), icon: 'i-lucide-circle-dot', items: store.byType.issue },
+  { key: 'pr' as const, label: t('bookmark.section.pulls'), icon: 'i-lucide-git-pull-request', items: store.byType.pr },
+  { key: 'repo' as const, label: t('bookmark.section.repos'), icon: 'i-lucide-folder-git-2', items: store.byType.repo },
+])
+</script>
+
+<template>
+  <div class="p-3 sm:p-4 lg:p-6 space-y-4 w-full">
+    <header class="flex items-center gap-2 sticky top-0 z-10 bg-default/80 backdrop-blur-sm py-1 -mx-3 px-3 sm:-mx-4 sm:px-4 lg:-mx-6 lg:px-6">
+      <UIcon
+        name="i-lucide-bookmark-check"
+        class="size-5 text-warning shrink-0"
+      />
+      <h1 class="text-lg font-semibold truncate">
+        {{ t('bookmark.title') }}
+      </h1>
+      <span class="text-sm text-muted">{{ store.items.length }}</span>
+    </header>
+
+    <div
+      v-if="store.loading && !store.loaded"
+      class="text-sm text-muted text-center py-8"
+    >
+      {{ t('common.loading') }}
+    </div>
+
+    <div
+      v-else-if="!store.items.length"
+      class="text-sm text-muted text-center py-12 max-w-md mx-auto"
+    >
+      {{ t('bookmark.empty') }}
+    </div>
+
+    <div
+      v-else
+      class="grid gap-4 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 items-start"
+    >
+      <section
+        v-for="section in sections"
+        :key="section.key"
+        class="rounded-lg border border-default overflow-hidden flex flex-col"
+      >
+        <header class="flex items-center gap-2 px-3 sm:px-4 py-2.5 bg-elevated/40 border-b border-default">
+          <UIcon
+            :name="section.icon"
+            class="size-4 text-muted shrink-0"
+          />
+          <span class="text-sm font-medium truncate">{{ section.label }}</span>
+          <span class="text-xs text-muted ml-auto tabular-nums">{{ section.items.length }}</span>
+        </header>
+        <p
+          v-if="!section.items.length"
+          class="px-3 sm:px-4 py-4 text-sm text-muted text-center"
+        >
+          {{ t('bookmark.sectionEmpty') }}
+        </p>
+        <ul
+          v-else
+          class="divide-y divide-default flex-1"
+        >
+          <li
+            v-for="item in section.items"
+            :key="item.id"
+            class="group flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 hover:bg-elevated transition-colors min-w-0"
+          >
+            <UAvatar
+              v-if="item.avatarUrl"
+              :src="item.avatarUrl"
+              :alt="item.repo ?? item.title"
+              size="2xs"
+              class="shrink-0"
+            />
+            <NuxtLink
+              :to="localePath(item.url)"
+              class="flex-1 min-w-0 flex flex-col gap-0.5"
+            >
+              <span class="text-sm text-default truncate hover:underline">{{ item.title }}</span>
+              <span
+                v-if="item.repo"
+                class="text-xs text-muted truncate"
+              >{{ item.repo }}{{ item.number ? ` #${item.number}` : '' }}</span>
+            </NuxtLink>
+            <UButton
+              icon="i-lucide-bookmark-x"
+              size="xs"
+              color="neutral"
+              variant="ghost"
+              :aria-label="t('bookmark.remove')"
+              class="shrink-0 cursor-pointer opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:opacity-100 transition-opacity"
+              @click="store.removeBookmark(item.id)"
+            />
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>

--- a/app/stores/bookmark.ts
+++ b/app/stores/bookmark.ts
@@ -1,0 +1,93 @@
+export const useBookmarkStore = defineStore('bookmark', () => {
+  const apiFetch = useRequestFetch()
+  const items = ref<Bookmark[]>([])
+  const loaded = ref(false)
+  const loading = ref(false)
+
+  async function loadIfNeeded() {
+    if (loaded.value || loading.value) return
+    loading.value = true
+    try {
+      items.value = await apiFetch<Bookmark[]>('/api/user/bookmarks')
+      loaded.value = true
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  function isBookmarked(id: string): boolean {
+    return items.value.some(b => b.id === id)
+  }
+
+  /**
+   * Toggle a bookmark. Optimistic — the server roundtrip is fire-and-forget;
+   * the result is reconciled when it returns.
+   */
+  async function toggleBookmark(input: Omit<Bookmark, 'addedAt'>) {
+    const existing = items.value.find(b => b.id === input.id)
+    if (existing) {
+      // Optimistic remove
+      items.value = items.value.filter(b => b.id !== input.id)
+      try {
+        const next = await $fetch<Bookmark[]>('/api/user/bookmarks', {
+          method: 'DELETE',
+          query: { id: input.id },
+        })
+        items.value = next
+      }
+      catch {
+        // Roll back on failure
+        items.value = [existing, ...items.value]
+      }
+      return
+    }
+    // Optimistic add
+    const optimistic: Bookmark = { ...input, addedAt: Date.now() }
+    items.value = [optimistic, ...items.value]
+    try {
+      const next = await $fetch<Bookmark[]>('/api/user/bookmarks', {
+        method: 'PUT',
+        body: optimistic,
+      })
+      items.value = next
+    }
+    catch {
+      items.value = items.value.filter(b => b.id !== input.id)
+    }
+  }
+
+  const byType = computed(() => ({
+    issue: items.value.filter(b => b.type === 'issue'),
+    pr: items.value.filter(b => b.type === 'pr'),
+    repo: items.value.filter(b => b.type === 'repo'),
+  }))
+
+  /** Direct removal by id (used from the bookmarks page). */
+  async function removeBookmark(id: string) {
+    const existing = items.value.find(b => b.id === id)
+    if (!existing) return
+    items.value = items.value.filter(b => b.id !== id)
+    try {
+      const next = await $fetch<Bookmark[]>('/api/user/bookmarks', {
+        method: 'DELETE',
+        query: { id },
+      })
+      items.value = next
+    }
+    catch {
+      items.value = [existing, ...items.value]
+    }
+  }
+
+  return {
+    items,
+    loaded,
+    loading,
+    byType,
+    loadIfNeeded,
+    isBookmarked,
+    toggleBookmark,
+    removeBookmark,
+  }
+})

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -16,6 +16,18 @@
     "error": "Fehler",
     "removeItem": "{item} entfernen"
   },
+  "bookmark": {
+    "title": "Lesezeichen",
+    "add": "Merken",
+    "remove": "Lesezeichen entfernen",
+    "empty": "Noch keine Lesezeichen. Klick auf das Lesezeichen-Icon bei einem Issue, PR oder Repo, um es hier zu sammeln.",
+    "sectionEmpty": "Hier ist noch nichts.",
+    "section": {
+      "issues": "Issues",
+      "pulls": "Pull Requests",
+      "repos": "Repositories"
+    }
+  },
   "cmdk": {
     "placeholder": "Suchen oder durchstöbern…",
     "loading": "Lädt…",
@@ -46,6 +58,7 @@
     "settings": "Einstellungen",
     "search": "Suchen...",
     "focus": "Fokus",
+    "bookmarks": "Lesezeichen",
     "profile": "Profil",
     "logout": "Abmelden"
   },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -16,6 +16,18 @@
     "error": "Error",
     "removeItem": "Remove {item}"
   },
+  "bookmark": {
+    "title": "Bookmarks",
+    "add": "Bookmark",
+    "remove": "Remove bookmark",
+    "empty": "No bookmarks yet. Tap the bookmark icon on any issue, PR or repo to keep it here.",
+    "sectionEmpty": "Nothing here yet.",
+    "section": {
+      "issues": "Issues",
+      "pulls": "Pull Requests",
+      "repos": "Repositories"
+    }
+  },
   "cmdk": {
     "placeholder": "Search or browse…",
     "loading": "Loading…",
@@ -46,6 +58,7 @@
     "settings": "Settings",
     "search": "Search...",
     "focus": "Focus",
+    "bookmarks": "Bookmarks",
     "profile": "Profile",
     "logout": "Log out"
   },

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -55,6 +55,42 @@
       },
       "additionalProperties": false
     },
+    "bookmark": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "add": {
+          "type": "string"
+        },
+        "remove": {
+          "type": "string"
+        },
+        "empty": {
+          "type": "string"
+        },
+        "sectionEmpty": {
+          "type": "string"
+        },
+        "section": {
+          "type": "object",
+          "properties": {
+            "issues": {
+              "type": "string"
+            },
+            "pulls": {
+              "type": "string"
+            },
+            "repos": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "cmdk": {
       "type": "object",
       "properties": {
@@ -143,6 +179,9 @@
           "type": "string"
         },
         "focus": {
+          "type": "string"
+        },
+        "bookmarks": {
           "type": "string"
         },
         "profile": {

--- a/server/api/user/bookmarks.delete.ts
+++ b/server/api/user/bookmarks.delete.ts
@@ -1,0 +1,14 @@
+export default defineEventHandler(async (event): Promise<Bookmark[]> => {
+  const session = await requireUserSession(event)
+  const id = getQuery<{ id?: string }>(event).id
+  if (!id || typeof id !== 'string') {
+    throw createError({ statusCode: 400, message: 'Missing id' })
+  }
+
+  const storage = useStorage('data')
+  const key = `users:${session.user.id}:bookmarks`
+  const current = (await storage.getItem<Bookmark[]>(key)) ?? []
+  const next = current.filter(b => b.id !== id)
+  await storage.setItem(key, next)
+  return next
+})

--- a/server/api/user/bookmarks.get.ts
+++ b/server/api/user/bookmarks.get.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event): Promise<Bookmark[]> => {
+  const session = await requireUserSession(event)
+  const storage = useStorage('data')
+  const bookmarks = await storage.getItem<Bookmark[]>(`users:${session.user.id}:bookmarks`)
+  return bookmarks ?? []
+})

--- a/server/api/user/bookmarks.put.ts
+++ b/server/api/user/bookmarks.put.ts
@@ -1,0 +1,64 @@
+const VALID_TYPES: BookmarkType[] = ['issue', 'pr', 'repo']
+const ID_MAX = 200
+const TITLE_MAX = 200
+const REPO_MAX = 100
+
+function isInternalPath(value: string): boolean {
+  return typeof value === 'string' && value.startsWith('/') && !value.startsWith('//')
+}
+
+function isHttpsUrl(value: string): boolean {
+  if (typeof value !== 'string') return false
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:'
+  }
+  catch {
+    return false
+  }
+}
+
+export default defineEventHandler(async (event): Promise<Bookmark[]> => {
+  const session = await requireUserSession(event)
+  const body = await readBody<Partial<Bookmark>>(event)
+
+  if (!body?.type || !VALID_TYPES.includes(body.type)) {
+    throw createError({ statusCode: 400, message: 'Invalid type' })
+  }
+  if (!body.id || typeof body.id !== 'string' || body.id.length > ID_MAX) {
+    throw createError({ statusCode: 400, message: 'Invalid id' })
+  }
+  if (!body.title || typeof body.title !== 'string') {
+    throw createError({ statusCode: 400, message: 'Missing title' })
+  }
+  if (!body.url || !isInternalPath(body.url)) {
+    throw createError({ statusCode: 400, message: 'Invalid url (must be internal path)' })
+  }
+  if (body.repo !== undefined && (typeof body.repo !== 'string' || body.repo.length > REPO_MAX)) {
+    throw createError({ statusCode: 400, message: 'Invalid repo' })
+  }
+  if (body.avatarUrl !== undefined && !isHttpsUrl(body.avatarUrl)) {
+    throw createError({ statusCode: 400, message: 'Invalid avatarUrl' })
+  }
+
+  const item: Bookmark = {
+    type: body.type,
+    id: body.id,
+    title: body.title.slice(0, TITLE_MAX),
+    repo: body.repo,
+    number: typeof body.number === 'number' ? body.number : undefined,
+    url: body.url,
+    avatarUrl: body.avatarUrl,
+    addedAt: Date.now(),
+  }
+
+  const storage = useStorage('data')
+  const key = `users:${session.user.id}:bookmarks`
+  const current = (await storage.getItem<Bookmark[]>(key)) ?? []
+
+  // Newest-first; replace if id already exists, cap to BOOKMARKS_CAP.
+  const next = [item, ...current.filter(b => b.id !== item.id)].slice(0, BOOKMARKS_CAP)
+  await storage.setItem(key, next)
+
+  return next
+})

--- a/shared/types/bookmark.ts
+++ b/shared/types/bookmark.ts
@@ -1,0 +1,23 @@
+export type BookmarkType = 'issue' | 'pr' | 'repo'
+
+export interface Bookmark {
+  type: BookmarkType
+  /** Stable identifier, e.g. `issue:owner/repo#123` or `repo:owner/name`. */
+  id: string
+  title: string
+  /** `owner/name` for issue/pr, identical to title for repo. */
+  repo?: string
+  number?: number
+  /** Internal app path. */
+  url: string
+  /** Optional avatar (repo owner / issue author / etc). */
+  avatarUrl?: string
+  addedAt: number
+}
+
+export const BOOKMARKS_CAP = 200
+
+export function bookmarkId(type: BookmarkType, repo: string, number?: number): string {
+  if (type === 'repo') return `repo:${repo}`
+  return `${type}:${repo}#${number}`
+}

--- a/shared/types/bookmark.ts
+++ b/shared/types/bookmark.ts
@@ -17,7 +17,12 @@ export interface Bookmark {
 
 export const BOOKMARKS_CAP = 200
 
+export function bookmarkId(type: 'repo', repo: string): string
+export function bookmarkId(type: 'issue' | 'pr', repo: string, number: number): string
 export function bookmarkId(type: BookmarkType, repo: string, number?: number): string {
   if (type === 'repo') return `repo:${repo}`
+  if (number === undefined) {
+    throw new Error(`bookmarkId: 'number' is required for type '${type}'`)
+  }
   return `${type}:${repo}#${number}`
 }

--- a/test/nuxt/bookmarkStore.test.ts
+++ b/test/nuxt/bookmarkStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { defineComponent, h } from 'vue'
-import { readBody as h3ReadBody } from 'h3'
+import { type H3Event, readBody as h3ReadBody } from 'h3'
 
 let serverState: Bookmark[] = []
 
@@ -21,7 +21,7 @@ registerEndpoint('/api/user/bookmarks', {
 
 registerEndpoint('/api/user/bookmarks', {
   method: 'DELETE',
-  handler: (event: { path: string }) => {
+  handler: (event: H3Event) => {
     const id = new URL(event.path, 'http://localhost').searchParams.get('id')
     if (id) serverState = serverState.filter(b => b.id !== id)
     return serverState

--- a/test/nuxt/bookmarkStore.test.ts
+++ b/test/nuxt/bookmarkStore.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
+import { defineComponent, h } from 'vue'
+import { readBody as h3ReadBody } from 'h3'
+
+let serverState: Bookmark[] = []
+
+registerEndpoint('/api/user/bookmarks', {
+  method: 'GET',
+  handler: () => serverState,
+})
+
+registerEndpoint('/api/user/bookmarks', {
+  method: 'PUT',
+  handler: async (event) => {
+    const body = await h3ReadBody(event) as Omit<Bookmark, 'addedAt'>
+    serverState = [{ ...body, addedAt: Date.now() } as Bookmark, ...serverState.filter(b => b.id !== body.id)]
+    return serverState
+  },
+})
+
+registerEndpoint('/api/user/bookmarks', {
+  method: 'DELETE',
+  handler: (event: { path: string }) => {
+    const id = new URL(event.path, 'http://localhost').searchParams.get('id')
+    if (id) serverState = serverState.filter(b => b.id !== id)
+    return serverState
+  },
+})
+
+async function withStore<T>(fn: (store: ReturnType<typeof useBookmarkStore>) => T | Promise<T>): Promise<T> {
+  let result: T
+  const Wrapper = defineComponent({
+    async setup() {
+      const store = useBookmarkStore()
+      store.items = []
+      store.loaded = false
+      store.loading = false
+      result = await fn(store)
+      return () => h('div')
+    },
+  })
+  await mountSuspended(Wrapper)
+  return result!
+}
+
+describe('bookmarkStore', () => {
+  it('loadIfNeeded fetches once', async () => {
+    serverState = [
+      { type: 'issue', id: 'issue:o/r#1', title: 'X', repo: 'o/r', number: 1, url: '/x', addedAt: 1 },
+    ]
+    await withStore(async (store) => {
+      await store.loadIfNeeded()
+      expect(store.items).toHaveLength(1)
+      expect(store.loaded).toBe(true)
+      // Second call is a no-op
+      await store.loadIfNeeded()
+      expect(store.items).toHaveLength(1)
+    })
+  })
+
+  it('isBookmarked reflects current state', async () => {
+    serverState = []
+    await withStore(async (store) => {
+      store.items = [
+        { type: 'repo', id: 'repo:o/r', title: 'r', repo: 'o/r', url: '/r', addedAt: 1 },
+      ]
+      expect(store.isBookmarked('repo:o/r')).toBe(true)
+      expect(store.isBookmarked('repo:o/x')).toBe(false)
+    })
+  })
+
+  it('toggleBookmark adds optimistically and confirms', async () => {
+    serverState = []
+    await withStore(async (store) => {
+      const id = bookmarkId('issue', 'o/r', 5)
+      const promise = store.toggleBookmark({
+        type: 'issue', id, title: 'T', repo: 'o/r', number: 5, url: '/i/5',
+      })
+      expect(store.isBookmarked(id)).toBe(true)
+      await promise
+      expect(store.isBookmarked(id)).toBe(true)
+      expect(serverState.some(b => b.id === id)).toBe(true)
+    })
+  })
+
+  it('toggleBookmark removes when already present', async () => {
+    const id = bookmarkId('repo', 'o/r')
+    serverState = [{ type: 'repo', id, title: 'r', repo: 'o/r', url: '/r', addedAt: 1 }]
+    await withStore(async (store) => {
+      store.items = [...serverState]
+      const promise = store.toggleBookmark({ type: 'repo', id, title: 'r', repo: 'o/r', url: '/r' })
+      expect(store.isBookmarked(id)).toBe(false)
+      await promise
+      expect(serverState).toHaveLength(0)
+    })
+  })
+
+  it('removeBookmark deletes by id', async () => {
+    const id = bookmarkId('pr', 'o/r', 9)
+    serverState = [{ type: 'pr', id, title: 'p', repo: 'o/r', number: 9, url: '/p/9', addedAt: 1 }]
+    await withStore(async (store) => {
+      store.items = [...serverState]
+      await store.removeBookmark(id)
+      expect(store.isBookmarked(id)).toBe(false)
+      expect(serverState).toHaveLength(0)
+    })
+  })
+
+  it('byType groups items by their type', async () => {
+    await withStore((store) => {
+      store.items = [
+        { type: 'issue', id: 'i1', title: 'a', repo: 'o/r', number: 1, url: '/a', addedAt: 1 },
+        { type: 'pr', id: 'p1', title: 'b', repo: 'o/r', number: 2, url: '/b', addedAt: 2 },
+        { type: 'repo', id: 'r1', title: 'c', repo: 'o/r', url: '/c', addedAt: 3 },
+        { type: 'issue', id: 'i2', title: 'd', repo: 'o/r', number: 4, url: '/d', addedAt: 4 },
+      ]
+      expect(store.byType.issue).toHaveLength(2)
+      expect(store.byType.pr).toHaveLength(1)
+      expect(store.byType.repo).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
Closes #279.

Server-side bookmark store (`users:{id}:bookmarks` in Nitro storage), separate from `recentStore` so the two don't entangle. UI hooked into issue rows; bookmarks page reachable via sidebar.

- `BookmarkStore` (Pinia) with optimistic add/remove/toggle, capped at 200, newest-first
- `/api/user/bookmarks` GET/PUT/DELETE
- `BookmarkButton` on `IssueRow`
- `/bookmarks` page: full-width responsive grid (1/2/3 cols), grouped by type
- Sidebar entry between Issues and Settings
- 6 store tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bookmark button to issue rows and a dedicated Bookmarks page with sections for issues, PRs, and repos
  * Sidebar navigation entry for Bookmarks and full i18n support for bookmark UI
  * Persistent, server-backed bookmarks with optimistic updates for instant UI feedback

* **Tests**
  * Added tests covering bookmark store behaviors (load, add/remove, grouping)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/291)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->