### PR TITLE
feat(prs): page skeleton with two highlight cards + main list

### DIFF
--- a/app/components/pull-request/PullRequestHighlightCard.vue
+++ b/app/components/pull-request/PullRequestHighlightCard.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { PullRequest } from '~~/shared/types/pull-request'
+import { buildWorkItemPath } from '~/utils/workItemPath'
+
+defineProps<{
+  title: string
+  iconKey: string
+  iconClass: string
+  items: PullRequest[]
+  loading: boolean
+  emptyText: string
+  totalCount: number | null
+  currentPage: number
+  totalPages: number
+  hasMore: boolean
+  hasPrevious: boolean
+  paging: 'next' | 'prev' | null
+}>()
+
+defineEmits<{
+  next: []
+  previous: []
+}>()
+
+const localePath = useLocalePath()
+
+// Approx. row height: avatar 2xs (~16px) + py-2 (16px) + text line ≈ 32px.
+const ROW_HEIGHT_REM = 2
+const maxListHeight = computed(() => `${ROW_HEIGHT_REM * HIGHLIGHT_CARD_VISIBLE_ITEMS}rem`)
+</script>
+
+<template>
+  <section class="rounded-lg border border-default overflow-hidden flex flex-col bg-default">
+    <header class="flex items-center gap-2 px-3 sm:px-4 py-2.5 bg-elevated/40 border-b border-default">
+      <UIcon
+        :name="iconKey"
+        class="size-4 shrink-0"
+        :class="iconClass"
+      />
+      <span class="text-sm font-medium truncate">{{ title }}</span>
+      <span class="text-xs text-muted ml-auto tabular-nums">
+        {{ loading ? '…' : (totalCount ?? items.length) }}
+      </span>
+    </header>
+
+    <ul
+      v-if="items.length"
+      class="divide-y divide-default flex-1 overflow-y-auto"
+      :style="{ maxHeight: maxListHeight }"
+    >
+      <li
+        v-for="pr in items"
+        :key="pr.id"
+        class="group hover:bg-elevated transition-colors"
+      >
+        <NuxtLink
+          :to="localePath(buildWorkItemPath(pr.repository.nameWithOwner, pr.number)!)"
+          class="flex items-center gap-2 px-3 sm:px-4 py-2 min-w-0"
+        >
+          <span class="text-xs text-muted tabular-nums shrink-0">#{{ pr.number }}</span>
+          <span class="flex-1 min-w-0 text-sm text-default truncate group-hover:underline">
+            {{ pr.title }}
+          </span>
+          <UAvatar
+            :src="pr.author.avatarUrl"
+            :alt="pr.author.login"
+            size="2xs"
+            class="shrink-0"
+          />
+        </NuxtLink>
+      </li>
+    </ul>
+
+    <p
+      v-else
+      class="px-3 sm:px-4 py-4 text-sm text-muted text-center"
+    >
+      {{ emptyText }}
+    </p>
+
+    <footer
+      v-if="totalPages > 1"
+      class="border-t border-default"
+    >
+      <UiPaginator
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :has-more="hasMore"
+        :has-previous="hasPrevious"
+        :paging="paging"
+        @next="$emit('next')"
+        @previous="$emit('previous')"
+      />
+    </footer>
+  </section>
+</template>

--- a/app/components/pull-request/PullRequestRow.vue
+++ b/app/components/pull-request/PullRequestRow.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import type { PullRequest } from '~~/shared/types/pull-request'
+
+const props = defineProps<{
+  pr: PullRequest
+}>()
+
+const localePath = useLocalePath()
+const { open: openProfile } = useUserProfileDialog()
+const createdAgo = useTimeAgo(computed(() => props.pr.createdAt))
+const updatedAgo = useTimeAgo(computed(() => props.pr.updatedAt))
+
+const repo = computed(() => props.pr.repository.nameWithOwner)
+
+const stateIcon = computed(() => {
+  if (props.pr.state === 'MERGED') return 'i-lucide-git-merge'
+  if (props.pr.state === 'CLOSED') return 'i-lucide-git-pull-request-closed'
+  if (props.pr.isDraft) return 'i-lucide-git-pull-request-draft'
+  return 'i-lucide-git-pull-request'
+})
+
+const stateColor = computed(() => {
+  if (props.pr.state === 'MERGED') return 'text-violet-500'
+  if (props.pr.state === 'CLOSED') return 'text-rose-500'
+  if (props.pr.isDraft) return 'text-neutral-400'
+  return 'text-emerald-500'
+})
+
+const router = useRouter()
+
+function navigate() {
+  router.push(localePath(buildWorkItemPath(repo.value, props.pr.number)!))
+}
+</script>
+
+<template>
+  <div
+    role="link"
+    tabindex="0"
+    class="group flex items-start gap-2 sm:gap-3 px-2 py-2.5 sm:px-4 sm:py-3 hover:bg-elevated transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-elevated"
+    @click="navigate"
+    @keydown.enter.self="navigate"
+    @keydown.space.self.prevent="navigate"
+  >
+    <UIcon
+      :name="stateIcon"
+      class="size-5 mt-0.5 shrink-0"
+      :class="stateColor"
+    />
+
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="font-medium text-highlighted hover:underline text-sm sm:text-base">
+          {{ pr.title }}
+        </span>
+        <UBadge
+          v-for="label in pr.labels"
+          :key="label.name"
+          color="neutral"
+          variant="subtle"
+          size="xs"
+          :style="{
+            backgroundColor: `#${label.color}1a`,
+            color: `#${label.color}`,
+          }"
+        >
+          {{ label.name }}
+        </UBadge>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3 mt-1 text-xs text-muted">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 cursor-pointer hover:underline"
+          @click.stop="openProfile(pr.author.login)"
+        >
+          <UAvatar
+            :src="pr.author.avatarUrl"
+            :alt="pr.author.login"
+            size="xs"
+          />
+          {{ pr.author.login }}
+        </button>
+        <span>#{{ pr.number }}</span>
+        <span>{{ createdAgo }}</span>
+        <span class="text-default">{{ updatedAgo }}</span>
+        <span class="font-mono text-[10px] text-muted/70 truncate max-w-35">
+          {{ pr.headRefName }} → {{ pr.baseRefName }}
+        </span>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-1 shrink-0">
+      <UTooltip
+        v-for="reviewer in pr.requestedReviewers"
+        :key="reviewer.login"
+        :text="reviewer.login"
+      >
+        <button
+          type="button"
+          class="cursor-pointer"
+          @click.stop="openProfile(reviewer.login)"
+        >
+          <UAvatar
+            :src="reviewer.avatarUrl"
+            :alt="reviewer.login"
+            size="xs"
+          />
+        </button>
+      </UTooltip>
+    </div>
+  </div>
+</template>

--- a/app/components/pull-request/PullRequestRowSkeleton.vue
+++ b/app/components/pull-request/PullRequestRowSkeleton.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="flex items-start gap-3 px-4 py-3 animate-pulse">
+    <div class="size-5 mt-0.5 rounded-full bg-elevated shrink-0" />
+    <div class="flex-1 space-y-2 min-w-0">
+      <div class="h-4 w-2/3 rounded bg-elevated" />
+      <div class="flex gap-2">
+        <div class="h-3 w-16 rounded bg-elevated" />
+        <div class="h-3 w-12 rounded bg-elevated" />
+        <div class="h-3 w-20 rounded bg-elevated" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/ui/SideBar.vue
+++ b/app/components/ui/SideBar.vue
@@ -171,6 +171,12 @@ const mainItems = computed<NavigationMenuItem[]>(() => [
     disabled: !loggedIn.value,
   },
   {
+    label: t('nav.pulls'),
+    icon: 'i-lucide-git-pull-request',
+    to: localePath('/pulls'),
+    disabled: !loggedIn.value,
+  },
+  {
     label: t('nav.bookmarks'),
     icon: 'i-lucide-bookmark',
     to: localePath('/bookmarks'),

--- a/app/pages/pulls/index.vue
+++ b/app/pages/pulls/index.vue
@@ -1,0 +1,167 @@
+<script lang="ts" setup>
+definePageMeta({
+  middleware: 'auth',
+  titleKey: 'nav.pulls',
+})
+
+const { t } = useI18n()
+const issueStore = useIssueStore()
+const store = usePullRequestStore()
+
+// Repo selection currently lives on issueStore (see IssueRepoSelect). The PR
+// store mirrors it via this watcher so picking a repo on either page keeps
+// both lists in sync. Extracting a generic RepoSelect is tracked separately.
+watch(() => issueStore.selectedRepo, (repo) => {
+  if (repo && repo !== store.selectedRepo) store.selectRepo(repo)
+}, { immediate: true })
+
+async function setStateFilter(state: 'open' | 'closed' | 'merged') {
+  if (store.stateFilter === state) return
+  await store.setStateFilter(state)
+}
+</script>
+
+<template>
+  <div class="p-2 sm:p-4 space-y-3 sm:space-y-4">
+    <div class="flex items-center gap-2">
+      <IssueRepoSelect />
+    </div>
+
+    <template v-if="store.selectedRepo">
+      <div
+        v-if="store.errorKey"
+        class="space-y-3"
+      >
+        <UAlert
+          :title="t(`pulls.error.${store.errorKey}.title`)"
+          :description="t(`pulls.error.${store.errorKey}.description`)"
+          :color="store.errorKey === 'rateLimited' ? 'warning' : 'error'"
+          :icon="store.errorKey === 'sessionExpired' ? 'i-lucide-log-out' : store.errorKey === 'rateLimited' ? 'i-lucide-clock' : 'i-lucide-alert-triangle'"
+        />
+        <UButton
+          :label="t('common.retry')"
+          icon="i-lucide-refresh-cw"
+          variant="outline"
+          @click="store.refresh()"
+        />
+      </div>
+
+      <template v-else>
+        <!-- Highlights: Ready-to-merge | Reviews-requested -->
+        <div
+          v-if="store.stateFilter === 'open'"
+          class="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2"
+        >
+          <PullRequestHighlightCard
+            :title="t('pulls.highlight.readyToMerge')"
+            icon-key="i-lucide-check-circle-2"
+            icon-class="text-emerald-500"
+            :items="store.readyToMerge.items"
+            :loading="store.readyToMerge.loading"
+            :empty-text="t('pulls.highlight.readyToMergeEmpty')"
+            :total-count="store.readyToMerge.totalCount"
+            :current-page="store.readyToMerge.currentPage"
+            :total-pages="store.readyToMerge.totalPages"
+            :has-more="store.readyToMerge.hasMore"
+            :has-previous="store.readyToMerge.hasPrevious"
+            :paging="store.readyToMerge.paging"
+            @next="store.loadHighlightNext('ready')"
+            @previous="store.loadHighlightPrevious('ready')"
+          />
+          <PullRequestHighlightCard
+            :title="t('pulls.highlight.reviewsRequested')"
+            icon-key="i-lucide-eye"
+            icon-class="text-rose-500"
+            :items="store.reviewsRequested.items"
+            :loading="store.reviewsRequested.loading"
+            :empty-text="t('pulls.highlight.reviewsRequestedEmpty')"
+            :total-count="store.reviewsRequested.totalCount"
+            :current-page="store.reviewsRequested.currentPage"
+            :total-pages="store.reviewsRequested.totalPages"
+            :has-more="store.reviewsRequested.hasMore"
+            :has-previous="store.reviewsRequested.hasPrevious"
+            :paging="store.reviewsRequested.paging"
+            @next="store.loadHighlightNext('reviews')"
+            @previous="store.loadHighlightPrevious('reviews')"
+          />
+        </div>
+
+        <!-- State tabs -->
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-2">
+          <UButton
+            :label="t('pulls.open')"
+            icon="i-lucide-git-pull-request"
+            :variant="store.stateFilter === 'open' ? 'solid' : 'outline'"
+            color="neutral"
+            size="sm"
+            @click="setStateFilter('open')"
+          />
+          <UButton
+            :label="t('pulls.merged')"
+            icon="i-lucide-git-merge"
+            :variant="store.stateFilter === 'merged' ? 'solid' : 'outline'"
+            color="neutral"
+            size="sm"
+            @click="setStateFilter('merged')"
+          />
+          <UButton
+            :label="t('pulls.closed')"
+            icon="i-lucide-git-pull-request-closed"
+            :variant="store.stateFilter === 'closed' ? 'solid' : 'outline'"
+            color="neutral"
+            size="sm"
+            @click="setStateFilter('closed')"
+          />
+        </div>
+
+        <!-- Initial loading -->
+        <template v-if="store.loading && !store.loaded">
+          <div class="rounded-lg border border-default divide-y divide-default overflow-hidden">
+            <PullRequestRowSkeleton
+              v-for="n in 6"
+              :key="n"
+            />
+          </div>
+        </template>
+
+        <!-- Main list -->
+        <template v-else-if="store.loaded">
+          <div
+            class="rounded-lg border border-default divide-y divide-default overflow-hidden transition-opacity duration-150"
+            :class="store.loading ? 'opacity-50 pointer-events-none' : ''"
+          >
+            <PullRequestRow
+              v-for="pr in store.prs"
+              :key="pr.id"
+              :pr="pr"
+            />
+            <p
+              v-if="!store.prs.length"
+              class="px-4 py-8 text-center text-sm text-muted"
+            >
+              {{ t('pulls.empty') }}
+            </p>
+          </div>
+
+          <UiPaginator
+            v-if="store.prs.length"
+            :current-page="store.currentPage"
+            :total-pages="store.totalPages"
+            :has-more="store.hasMore"
+            :has-previous="store.hasPrevious"
+            :paging="store.paging"
+            @next="store.loadNextPage()"
+            @previous="store.loadPreviousPage()"
+          />
+        </template>
+      </template>
+    </template>
+
+    <p
+      v-else
+      class="text-sm text-muted text-center py-12"
+    >
+      {{ t('pulls.selectRepo') }}
+    </p>
+  </div>
+</template>

--- a/app/stores/pullRequests.ts
+++ b/app/stores/pullRequests.ts
@@ -1,0 +1,272 @@
+import type { PullRequest, PullRequestListResponse } from '~~/shared/types/pull-request'
+
+export type PrStateFilter = 'open' | 'closed' | 'merged'
+
+interface FetchOptions {
+  refresh?: boolean
+}
+
+const PAGE_SIZE = 20
+const HIGHLIGHT_PAGE_SIZE = HIGHLIGHT_CARD_VISIBLE_ITEMS
+
+/**
+ * Internal helper — owns paginated state for a single highlight card
+ * (ready-to-merge, reviews-requested). Mirrors the cursor-stack pattern from
+ * the issue store.
+ */
+function createHighlightSection(endpoint: string, pageSize: number) {
+  const apiFetch = useRequestFetch()
+
+  const items = shallowRef<PullRequest[]>([])
+  const totalCount = ref<number | null>(null)
+  const cursorStack = ref<(string | null)[]>([null])
+  const nextCursor = ref<string | null>(null)
+  const hasMore = ref(false)
+  const loading = ref(false)
+  const paging = ref<'next' | 'prev' | null>(null)
+
+  const currentPage = computed(() => Math.max(1, cursorStack.value.length))
+  const hasPrevious = computed(() => currentPage.value > 1)
+  const totalPages = computed(() => {
+    if (totalCount.value === null) return 1
+    return Math.max(1, Math.ceil(totalCount.value / pageSize))
+  })
+
+  function reset() {
+    items.value = []
+    totalCount.value = null
+    cursorStack.value = [null]
+    nextCursor.value = null
+    hasMore.value = false
+  }
+
+  async function fetchPage(repo: string) {
+    loading.value = true
+    try {
+      const after = cursorStack.value[cursorStack.value.length - 1]
+      const response = await apiFetch<PullRequestListResponse>(endpoint, {
+        params: { repo, first: pageSize, after: after ?? undefined },
+      })
+      items.value = response.items
+      totalCount.value = response.totalCount
+      hasMore.value = response.pageInfo.hasNextPage
+      nextCursor.value = response.pageInfo.endCursor
+    }
+    catch {
+      // Highlights are an enhancement — fail silently, leave empty.
+      reset()
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  async function loadNext(repo: string) {
+    if (!hasMore.value || paging.value || !nextCursor.value) return
+    paging.value = 'next'
+    try {
+      cursorStack.value.push(nextCursor.value)
+      await fetchPage(repo)
+    }
+    finally {
+      paging.value = null
+    }
+  }
+
+  async function loadPrevious(repo: string) {
+    if (!hasPrevious.value || paging.value) return
+    paging.value = 'prev'
+    try {
+      cursorStack.value.pop()
+      await fetchPage(repo)
+    }
+    finally {
+      paging.value = null
+    }
+  }
+
+  return {
+    items,
+    totalCount,
+    hasMore,
+    hasPrevious,
+    paging,
+    loading,
+    currentPage,
+    totalPages,
+    fetchPage,
+    loadNext,
+    loadPrevious,
+    reset,
+  }
+}
+
+export const usePullRequestStore = defineStore('pullRequests', () => {
+  const apiFetch = useRequestFetch()
+
+  const selectedRepo = ref<string | null>(null)
+  const prs = shallowRef<PullRequest[]>([])
+  const loaded = ref(false)
+  const loading = ref(false)
+  const errorKey = ref<string | null>(null)
+
+  const stateFilter = ref<PrStateFilter>('open')
+
+  const totalCount = ref<number | null>(null)
+  const cursorStack = ref<(string | null)[]>([null])
+  const nextCursor = ref<string | null>(null)
+  const hasMore = ref(false)
+  const paging = ref<'next' | 'prev' | null>(null)
+
+  const readyToMerge = createHighlightSection('/api/pull-requests/ready-to-merge', HIGHLIGHT_PAGE_SIZE)
+  const reviewsRequested = createHighlightSection('/api/pull-requests/reviews-requested', HIGHLIGHT_PAGE_SIZE)
+
+  const currentPage = computed(() => Math.max(1, cursorStack.value.length))
+  const hasPrevious = computed(() => currentPage.value > 1)
+  const totalPages = computed(() => {
+    if (totalCount.value === null) return 1
+    return Math.max(1, Math.ceil(totalCount.value / PAGE_SIZE))
+  })
+
+  function mapErrorKey(err: unknown): string {
+    const status = (err as { statusCode?: number }).statusCode
+    if (status === 401) return 'sessionExpired'
+    if (status === 403) return 'rateLimited'
+    if (status === 404) return 'notFound'
+    return 'generic'
+  }
+
+  async function fetchPrs(opts: FetchOptions = {}) {
+    if (!selectedRepo.value) return
+    if (loading.value && !opts.refresh) return
+
+    loading.value = true
+    errorKey.value = null
+    try {
+      const after = cursorStack.value[cursorStack.value.length - 1]
+      const response = await apiFetch<PullRequestListResponse>('/api/pull-requests', {
+        params: {
+          repo: selectedRepo.value,
+          state: stateFilter.value,
+          first: PAGE_SIZE,
+          after: after ?? undefined,
+        },
+      })
+      prs.value = response.items
+      totalCount.value = response.totalCount
+      hasMore.value = response.pageInfo.hasNextPage
+      nextCursor.value = response.pageInfo.endCursor
+      loaded.value = true
+    }
+    catch (err) {
+      errorKey.value = mapErrorKey(err)
+      prs.value = []
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchHighlights() {
+    if (!selectedRepo.value) return
+    if (stateFilter.value !== 'open') {
+      readyToMerge.reset()
+      reviewsRequested.reset()
+      return
+    }
+    await Promise.all([
+      readyToMerge.fetchPage(selectedRepo.value),
+      reviewsRequested.fetchPage(selectedRepo.value),
+    ])
+  }
+
+  async function selectRepo(repo: string) {
+    if (repo === selectedRepo.value && loaded.value) return
+    selectedRepo.value = repo
+    cursorStack.value = [null]
+    readyToMerge.reset()
+    reviewsRequested.reset()
+    loaded.value = false
+    await Promise.all([fetchPrs({ refresh: true }), fetchHighlights()])
+  }
+
+  async function setStateFilter(state: PrStateFilter) {
+    if (stateFilter.value === state) return
+    stateFilter.value = state
+    cursorStack.value = [null]
+    readyToMerge.reset()
+    reviewsRequested.reset()
+    await Promise.all([fetchPrs({ refresh: true }), fetchHighlights()])
+  }
+
+  async function loadNextPage() {
+    if (!hasMore.value || paging.value || !nextCursor.value) return
+    paging.value = 'next'
+    try {
+      cursorStack.value.push(nextCursor.value)
+      await fetchPrs({ refresh: true })
+    }
+    finally {
+      paging.value = null
+    }
+  }
+
+  async function loadPreviousPage() {
+    if (!hasPrevious.value || paging.value) return
+    paging.value = 'prev'
+    try {
+      cursorStack.value.pop()
+      await fetchPrs({ refresh: true })
+    }
+    finally {
+      paging.value = null
+    }
+  }
+
+  async function refresh() {
+    cursorStack.value = [null]
+    readyToMerge.reset()
+    reviewsRequested.reset()
+    loaded.value = false
+    await Promise.all([fetchPrs({ refresh: true }), fetchHighlights()])
+  }
+
+  // Wrappers so callers don't need to thread `selectedRepo` through.
+  async function loadHighlightNext(section: 'ready' | 'reviews') {
+    if (!selectedRepo.value) return
+    const target = section === 'ready' ? readyToMerge : reviewsRequested
+    await target.loadNext(selectedRepo.value)
+  }
+
+  async function loadHighlightPrevious(section: 'ready' | 'reviews') {
+    if (!selectedRepo.value) return
+    const target = section === 'ready' ? readyToMerge : reviewsRequested
+    await target.loadPrevious(selectedRepo.value)
+  }
+
+  return {
+    selectedRepo,
+    prs,
+    readyToMerge,
+    reviewsRequested,
+    loaded,
+    loading,
+    errorKey,
+    stateFilter,
+    totalCount,
+    hasMore,
+    hasPrevious,
+    paging,
+    currentPage,
+    totalPages,
+    fetchPrs,
+    fetchHighlights,
+    selectRepo,
+    setStateFilter,
+    loadNextPage,
+    loadPreviousPage,
+    loadHighlightNext,
+    loadHighlightPrevious,
+    refresh,
+  }
+})

--- a/app/stores/pullRequests.ts
+++ b/app/stores/pullRequests.ts
@@ -40,24 +40,32 @@ function createHighlightSection(endpoint: string, pageSize: number) {
     hasMore.value = false
   }
 
+  // Monotonic request id — only the most recent fetch is allowed to mutate
+  // observable state. Protects against stale responses winning when the user
+  // switches repos / pages quickly.
+  let fetchSeq = 0
+
   async function fetchPage(repo: string) {
+    const id = ++fetchSeq
     loading.value = true
     try {
       const after = cursorStack.value[cursorStack.value.length - 1]
       const response = await apiFetch<PullRequestListResponse>(endpoint, {
         params: { repo, first: pageSize, after: after ?? undefined },
       })
+      if (id !== fetchSeq) return
       items.value = response.items
       totalCount.value = response.totalCount
       hasMore.value = response.pageInfo.hasNextPage
       nextCursor.value = response.pageInfo.endCursor
     }
     catch {
+      if (id !== fetchSeq) return
       // Highlights are an enhancement — fail silently, leave empty.
       reset()
     }
     finally {
-      loading.value = false
+      if (id === fetchSeq) loading.value = false
     }
   }
 
@@ -136,10 +144,15 @@ export const usePullRequestStore = defineStore('pullRequests', () => {
     return 'generic'
   }
 
+  // Monotonic request id for the main list — protects against stale responses
+  // overwriting newer state on rapid repo / state switches.
+  let fetchPrsSeq = 0
+
   async function fetchPrs(opts: FetchOptions = {}) {
     if (!selectedRepo.value) return
     if (loading.value && !opts.refresh) return
 
+    const id = ++fetchPrsSeq
     loading.value = true
     errorKey.value = null
     try {
@@ -152,6 +165,7 @@ export const usePullRequestStore = defineStore('pullRequests', () => {
           after: after ?? undefined,
         },
       })
+      if (id !== fetchPrsSeq) return
       prs.value = response.items
       totalCount.value = response.totalCount
       hasMore.value = response.pageInfo.hasNextPage
@@ -159,11 +173,12 @@ export const usePullRequestStore = defineStore('pullRequests', () => {
       loaded.value = true
     }
     catch (err) {
+      if (id !== fetchPrsSeq) return
       errorKey.value = mapErrorKey(err)
       prs.value = []
     }
     finally {
-      loading.value = false
+      if (id === fetchPrsSeq) loading.value = false
     }
   }
 

--- a/app/utils/uiLimits.ts
+++ b/app/utils/uiLimits.ts
@@ -1,0 +1,6 @@
+/**
+ * UI display limits used across the app. Centralized so that future user
+ * settings can override these in one place (e.g. `useUserSettings` composable
+ * could expose a derived value that falls back to these defaults).
+ */
+export const HIGHLIGHT_CARD_VISIBLE_ITEMS = 12

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -19,7 +19,7 @@
   "pulls": {
     "selectRepo": "Wähle ein Repository, um Pull Requests zu sehen.",
     "open": "Offen",
-    "merged": "Gemerged",
+    "merged": "Gemergt",
     "closed": "Geschlossen",
     "empty": "Keine Pull Requests in diesem Status.",
     "highlight": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -16,6 +16,37 @@
     "error": "Fehler",
     "removeItem": "{item} entfernen"
   },
+  "pulls": {
+    "selectRepo": "Wähle ein Repository, um Pull Requests zu sehen.",
+    "open": "Offen",
+    "merged": "Gemerged",
+    "closed": "Geschlossen",
+    "empty": "Keine Pull Requests in diesem Status.",
+    "highlight": {
+      "readyToMerge": "Bereit zum Mergen",
+      "readyToMergeEmpty": "Aktuell ist nichts von dir komplett grün.",
+      "reviewsRequested": "Reviews angefragt",
+      "reviewsRequestedEmpty": "Niemand wartet hier auf dein Review."
+    },
+    "error": {
+      "sessionExpired": {
+        "title": "Session abgelaufen",
+        "description": "Bitte melde dich erneut an."
+      },
+      "rateLimited": {
+        "title": "GitHub-Rate-Limit erreicht",
+        "description": "Bitte in einer Minute erneut versuchen."
+      },
+      "notFound": {
+        "title": "Repository nicht gefunden",
+        "description": "Prüfe den Repo-Namen oder deine Zugriffsrechte."
+      },
+      "generic": {
+        "title": "Etwas ist schiefgelaufen",
+        "description": "Pull Requests konnten nicht geladen werden. Bitte erneut versuchen."
+      }
+    }
+  },
   "bookmark": {
     "title": "Lesezeichen",
     "add": "Merken",
@@ -44,7 +75,7 @@
     "subtitlePrivateFork": "Privat · Fork",
     "scopeMine": "Meine Repos",
     "scopeGlobal": "Ganz GitHub",
-    "scopeHintGlobal": "Sucht in ganz GitHub — kann langsamer sein.",
+    "scopeHintGlobal": "Sucht in ganz GitHub - kann langsamer sein.",
     "scopeAriaToggle": "Such-Bereich umschalten",
     "footerNavigate": "navigieren",
     "footerSelect": "öffnen"
@@ -58,6 +89,7 @@
     "settings": "Einstellungen",
     "search": "Suchen...",
     "focus": "Fokus",
+    "pulls": "Pull Requests",
     "bookmarks": "Lesezeichen",
     "profile": "Profil",
     "logout": "Abmelden"
@@ -79,7 +111,7 @@
       "focus": {
         "badge": "Fokus",
         "title": "Dein Dashboard, dein Flow",
-        "description": "Alles, was dir wichtig ist — Issues, Pull Requests, Benachrichtigungen — in einer übersichtlichen Ansicht. Kein Durcheinander.",
+        "description": "Alles, was dir wichtig ist - Issues, Pull Requests, Benachrichtigungen - in einer übersichtlichen Ansicht. Kein Durcheinander.",
         "mockup": {
           "merged": "Gemergt",
           "review": "Review",
@@ -104,7 +136,7 @@
       "profile": {
         "badge": "Profil",
         "title": "Deine Identität auf einen Blick",
-        "description": "Bearbeite dein GitHub-Profil, README, Status und Social Links — alles an einem Ort. Kein Kontextwechsel."
+        "description": "Bearbeite dein GitHub-Profil, README, Status und Social Links - alles an einem Ort. Kein Kontextwechsel."
       }
     },
     "openSource": {
@@ -209,7 +241,7 @@
       "forkedFrom": "Geforkt von",
       "lists": "Listen",
       "workItems": "Work Items",
-      "workItemsHint": "Issues und Pull Requests kombiniert — nach Priorität sortiert.",
+      "workItemsHint": "Issues und Pull Requests kombiniert - nach Priorität sortiert.",
       "specialFiles": {
         "readme": "README",
         "codeOfConduct": "Verhaltensregeln",
@@ -252,7 +284,7 @@
       },
       "ownBanner": {
         "title": "Das ist Flumen",
-        "description": "Das Tool, das du gerade benutzt. Offen gebaut, für Maintainer die bessere Tools verdienen. Kein Tracking, keine Paywalls — nur Fokus.",
+        "description": "Das Tool, das du gerade benutzt. Offen gebaut, für Maintainer die bessere Tools verdienen. Kein Tracking, keine Paywalls - nur Fokus.",
         "goals": {
           "openSource": "Vollständig Open Source",
           "noTracking": "Kein Tracking",
@@ -478,7 +510,7 @@
       "blankIssueDescription": "Von Grund auf ein neues Issue erstellen.",
       "backToTemplates": "Zurück zu Vorlagen",
       "similarHeading": "Möglicherweise verwandte Issues",
-      "similarHint": "Bitte vor dem Erstellen ansehen — vermeide Duplikate."
+      "similarHint": "Bitte vor dem Erstellen ansehen - vermeide Duplikate."
     },
     "error": {
       "fetchError": {
@@ -543,9 +575,9 @@
     },
     "merge": {
       "readyToMerge": "Bereit zum Mergen",
-      "hasConflicts": "Merge-Konflikte — vor dem Mergen auflösen",
+      "hasConflicts": "Merge-Konflikte - vor dem Mergen auflösen",
       "blocked": "Checks oder Reviews blockieren den Merge",
-      "blockedBypass": "Blockiert — du kannst als Admin umgehen",
+      "blockedBypass": "Blockiert - du kannst als Admin umgehen",
       "merge": "Mergen",
       "keepAll": "Alle Commits behalten",
       "keepAllDesc": "Alle {count} Commits werden mit einem Merge-Commit in den Zielbranch übernommen.",
@@ -570,8 +602,8 @@
       "branchDeleteFailed": "Branch konnte nicht gelöscht werden",
       "error": {
         "forbidden": "Du hast keine Berechtigung, diesen Pull Request zu mergen",
-        "notMergeable": "Dieser Pull Request kann nicht gemergt werden — Checks, Reviews oder Branch-Schutzregeln blockieren den Merge",
-        "branchModified": "Der Branch wurde zwischenzeitlich geändert — bitte prüfen und erneut versuchen",
+        "notMergeable": "Dieser Pull Request kann nicht gemergt werden - Checks, Reviews oder Branch-Schutzregeln blockieren den Merge",
+        "branchModified": "Der Branch wurde zwischenzeitlich geändert - bitte prüfen und erneut versuchen",
         "validationFailed": "Ungültige Merge-Parameter",
         "unknown": "Beim Mergen ist ein unerwarteter Fehler aufgetreten"
       }
@@ -766,13 +798,13 @@
   "dashboard": {
     "description": "Was gerade deine Aufmerksamkeit braucht.",
     "waitingOnMe": {
-      "collapsed": "{count} Einträge — Ø {days}T Wartezeit"
+      "collapsed": "{count} Einträge - Ø {days}T Wartezeit"
     },
     "prHealth": {
       "title": "PR-Zustand",
       "empty": "Alle deine PRs sind gesund.",
       "summary": "{issues} Probleme: {ci} CI-Fehler, {conflicts} Merge-Konflikte",
-      "collapsed": "{count} Probleme — {ci} CI, {conflicts} Konflikte",
+      "collapsed": "{count} Probleme - {ci} CI, {conflicts} Konflikte",
       "ageDays": "{days}T alt",
       "reason": {
         "ci-failing": "CI schlägt fehl",
@@ -795,7 +827,7 @@
       "prsMerged": "PRs gemerged",
       "issuesClosed": "Issues geschlossen",
       "moreItems": "+{count} weitere",
-      "collapsed": "{ratio}x — {resolved} erledigt, {incoming} eingegangen"
+      "collapsed": "{ratio}x - {resolved} erledigt, {incoming} eingegangen"
     }
   },
   "focus": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -16,6 +16,37 @@
     "error": "Error",
     "removeItem": "Remove {item}"
   },
+  "pulls": {
+    "selectRepo": "Select a repository to see pull requests.",
+    "open": "Open",
+    "merged": "Merged",
+    "closed": "Closed",
+    "empty": "No pull requests in this state.",
+    "highlight": {
+      "readyToMerge": "Ready to merge",
+      "readyToMergeEmpty": "Nothing of yours is fully green right now.",
+      "reviewsRequested": "Reviews requested",
+      "reviewsRequestedEmpty": "No one is waiting on your review here."
+    },
+    "error": {
+      "sessionExpired": {
+        "title": "Session expired",
+        "description": "Please sign in again to continue."
+      },
+      "rateLimited": {
+        "title": "GitHub rate limit reached",
+        "description": "Try again in a minute."
+      },
+      "notFound": {
+        "title": "Repository not found",
+        "description": "Check the repo name or your access permissions."
+      },
+      "generic": {
+        "title": "Something went wrong",
+        "description": "We could not load pull requests. Please try again."
+      }
+    }
+  },
   "bookmark": {
     "title": "Bookmarks",
     "add": "Bookmark",
@@ -44,7 +75,7 @@
     "subtitlePrivateFork": "Private · Fork",
     "scopeMine": "My repos",
     "scopeGlobal": "All of GitHub",
-    "scopeHintGlobal": "Searching all of GitHub — may be slower.",
+    "scopeHintGlobal": "Searching all of GitHub - may be slower.",
     "scopeAriaToggle": "Toggle search scope",
     "footerNavigate": "navigate",
     "footerSelect": "select"
@@ -58,6 +89,7 @@
     "settings": "Settings",
     "search": "Search...",
     "focus": "Focus",
+    "pulls": "Pull Requests",
     "bookmarks": "Bookmarks",
     "profile": "Profile",
     "logout": "Log out"
@@ -79,7 +111,7 @@
       "focus": {
         "badge": "Focus",
         "title": "Your dashboard, your flow",
-        "description": "Everything you care about — issues, pull requests, notifications — in one clean overview. No clutter, no noise.",
+        "description": "Everything you care about - issues, pull requests, notifications - in one clean overview. No clutter, no noise.",
         "mockup": {
           "merged": "merged",
           "review": "review",
@@ -104,7 +136,7 @@
       "profile": {
         "badge": "Profile",
         "title": "Your identity, at a glance",
-        "description": "Edit your GitHub profile, README, status, and social links — all from one place. No context switching."
+        "description": "Edit your GitHub profile, README, status, and social links - all from one place. No context switching."
       }
     },
     "openSource": {
@@ -209,7 +241,7 @@
       "forkedFrom": "Forked from",
       "lists": "Lists",
       "workItems": "Work Items",
-      "workItemsHint": "Issues and pull requests combined — sorted by priority.",
+      "workItemsHint": "Issues and pull requests combined - sorted by priority.",
       "specialFiles": {
         "readme": "README",
         "codeOfConduct": "Code of Conduct",
@@ -252,7 +284,7 @@
       },
       "ownBanner": {
         "title": "This is Flumen",
-        "description": "The tool you're using right now. Built in the open, for maintainers who deserve better tools. No tracking, no paywalls — just focus.",
+        "description": "The tool you're using right now. Built in the open, for maintainers who deserve better tools. No tracking, no paywalls - just focus.",
         "goals": {
           "openSource": "Fully open source",
           "noTracking": "Zero tracking",
@@ -478,7 +510,7 @@
       "blankIssueDescription": "Start from scratch with an empty issue.",
       "backToTemplates": "Back to templates",
       "similarHeading": "Possibly related issues",
-      "similarHint": "Open one to check before creating — avoid duplicates."
+      "similarHint": "Open one to check before creating - avoid duplicates."
     },
     "error": {
       "fetchError": {
@@ -543,9 +575,9 @@
     },
     "merge": {
       "readyToMerge": "Ready to merge",
-      "hasConflicts": "Merge conflicts — resolve before merging",
+      "hasConflicts": "Merge conflicts - resolve before merging",
       "blocked": "Checks or reviews are blocking merge",
-      "blockedBypass": "Blocked — you can bypass as admin",
+      "blockedBypass": "Blocked - you can bypass as admin",
       "merge": "Merge",
       "keepAll": "Keep all commits",
       "keepAllDesc": "All {count} commits are added to the base branch with a merge commit.",
@@ -570,8 +602,8 @@
       "branchDeleteFailed": "Failed to delete branch",
       "error": {
         "forbidden": "You don't have permission to merge this pull request",
-        "notMergeable": "This pull request cannot be merged — checks, reviews, or branch protection may be blocking it",
-        "branchModified": "The branch was modified in the meantime — please review and try again",
+        "notMergeable": "This pull request cannot be merged - checks, reviews, or branch protection may be blocking it",
+        "branchModified": "The branch was modified in the meantime - please review and try again",
         "validationFailed": "Invalid merge parameters",
         "unknown": "An unexpected error occurred while merging"
       }
@@ -766,13 +798,13 @@
   "dashboard": {
     "description": "What needs your attention right now.",
     "waitingOnMe": {
-      "collapsed": "{count} items — avg. {days}d waiting"
+      "collapsed": "{count} items - avg. {days}d waiting"
     },
     "prHealth": {
       "title": "PR Health",
       "empty": "All your PRs are healthy.",
       "summary": "{issues} issues: {ci} CI failures, {conflicts} merge conflicts",
-      "collapsed": "{count} issues — {ci} CI, {conflicts} conflicts",
+      "collapsed": "{count} issues - {ci} CI, {conflicts} conflicts",
       "ageDays": "{days}d old",
       "reason": {
         "ci-failing": "CI is failing",
@@ -795,7 +827,7 @@
       "prsMerged": "PRs merged",
       "issuesClosed": "Issues closed",
       "moreItems": "+{count} more",
-      "collapsed": "{ratio}x — {resolved} resolved, {incoming} incoming"
+      "collapsed": "{ratio}x - {resolved} resolved, {incoming} incoming"
     }
   },
   "focus": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -55,6 +55,99 @@
       },
       "additionalProperties": false
     },
+    "pulls": {
+      "type": "object",
+      "properties": {
+        "selectRepo": {
+          "type": "string"
+        },
+        "open": {
+          "type": "string"
+        },
+        "merged": {
+          "type": "string"
+        },
+        "closed": {
+          "type": "string"
+        },
+        "empty": {
+          "type": "string"
+        },
+        "highlight": {
+          "type": "object",
+          "properties": {
+            "readyToMerge": {
+              "type": "string"
+            },
+            "readyToMergeEmpty": {
+              "type": "string"
+            },
+            "reviewsRequested": {
+              "type": "string"
+            },
+            "reviewsRequestedEmpty": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "sessionExpired": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "rateLimited": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "notFound": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "generic": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "bookmark": {
       "type": "object",
       "properties": {
@@ -179,6 +272,9 @@
           "type": "string"
         },
         "focus": {
+          "type": "string"
+        },
+        "pulls": {
           "type": "string"
         },
         "bookmarks": {

--- a/server/api/pull-requests/index.get.ts
+++ b/server/api/pull-requests/index.get.ts
@@ -1,0 +1,28 @@
+import type { PullRequestListResponse } from '~~/shared/types/pull-request'
+
+export default defineEventHandler(async (event): Promise<PullRequestListResponse> => {
+  const { token } = await getSessionToken(event)
+  const { state = 'open', repo, first = '20', after } = getQuery<{
+    state?: string
+    repo?: string
+    first?: string
+    after?: string
+  }>(event)
+
+  if (!repo || !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    throw createError({ statusCode: 400, message: 'Missing or invalid repo query parameter' })
+  }
+
+  const pageSize = Math.min(Math.max(Number(first) || 20, 1), 100)
+  const stateQ = state === 'closed' ? 'is:closed' : state === 'merged' ? 'is:merged' : 'is:open'
+  const query = `is:pr ${stateQ} repo:${repo} sort:updated-desc`
+
+  const page = await searchPullRequests(token, query, { first: pageSize, after })
+  const items = await getOrFetchPullRequests(token, page.minimalNodes)
+
+  return {
+    items,
+    totalCount: page.totalCount,
+    pageInfo: page.pageInfo,
+  }
+})

--- a/server/api/pull-requests/ready-to-merge.get.ts
+++ b/server/api/pull-requests/ready-to-merge.get.ts
@@ -1,0 +1,29 @@
+import type { PullRequestListResponse } from '~~/shared/types/pull-request'
+
+export default defineEventHandler(async (event): Promise<PullRequestListResponse> => {
+  const { token } = await getSessionToken(event)
+  const { repo, first = '12', after } = getQuery<{
+    repo?: string
+    first?: string
+    after?: string
+  }>(event)
+
+  if (!repo || !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    throw createError({ statusCode: 400, message: 'Missing or invalid repo query parameter' })
+  }
+
+  const pageSize = Math.min(Math.max(Number(first) || 12, 1), 50)
+  const query = `is:pr is:open draft:false repo:${repo} review:approved status:success sort:updated-desc`
+
+  const page = await searchPullRequests(token, query, { first: pageSize, after })
+  const resolved = await getOrFetchPullRequests(token, page.minimalNodes)
+
+  // GitHub Search has no `mergeable` qualifier — drop conflicting PRs after the fact.
+  const items = resolved.filter(pr => pr.mergeable !== 'CONFLICTING')
+
+  return {
+    items,
+    totalCount: page.totalCount,
+    pageInfo: page.pageInfo,
+  }
+})

--- a/server/api/pull-requests/reviews-requested.get.ts
+++ b/server/api/pull-requests/reviews-requested.get.ts
@@ -1,0 +1,26 @@
+import type { PullRequestListResponse } from '~~/shared/types/pull-request'
+
+export default defineEventHandler(async (event): Promise<PullRequestListResponse> => {
+  const { token, login } = await getSessionToken(event)
+  const { repo, first = '12', after } = getQuery<{
+    repo?: string
+    first?: string
+    after?: string
+  }>(event)
+
+  if (!repo || !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    throw createError({ statusCode: 400, message: 'Missing or invalid repo query parameter' })
+  }
+
+  const pageSize = Math.min(Math.max(Number(first) || 12, 1), 50)
+  const query = `is:pr is:open draft:false repo:${repo} review-requested:${login} sort:updated-desc`
+
+  const page = await searchPullRequests(token, query, { first: pageSize, after })
+  const items = await getOrFetchPullRequests(token, page.minimalNodes)
+
+  return {
+    items,
+    totalCount: page.totalCount,
+    pageInfo: page.pageInfo,
+  }
+})

--- a/server/utils/pull-request-cache.ts
+++ b/server/utils/pull-request-cache.ts
@@ -1,0 +1,117 @@
+import type { MinimalPullRequestNode, PullRequest } from '~~/shared/types/pull-request'
+import type { GraphQLPullRequestNode } from '~~/shared/utils/pull-request'
+import { toPullRequest } from '~~/shared/utils/pull-request'
+
+const PR_FIELDS = `
+  id
+  number
+  title
+  state
+  isDraft
+  url
+  createdAt
+  updatedAt
+  closedAt
+  mergedAt
+  additions
+  deletions
+  changedFiles
+  headRefName
+  baseRefName
+  mergeable
+  reviewDecision
+  author { login avatarUrl }
+  labels(first: 10) { nodes { name color } }
+  assignees(first: 5) { nodes { login avatarUrl } }
+  reviewRequests(first: 10) {
+    nodes {
+      requestedReviewer {
+        ... on User { login avatarUrl }
+      }
+    }
+  }
+  comments { totalCount }
+  closingIssuesReferences(first: 0) { totalCount }
+  commits(last: 1) {
+    nodes {
+      commit { statusCheckRollup { state } }
+    }
+  }
+  repository { nameWithOwner name owner { login } }
+`
+
+const NODES_QUERY = `
+query($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    ... on PullRequest {
+      ${PR_FIELDS}
+    }
+  }
+}
+`
+
+interface CachedPullRequestNode {
+  updatedAt: string
+  node: GraphQLPullRequestNode
+}
+
+/**
+ * Given minimal PR nodes (id + updatedAt), resolves full PullRequest objects
+ * using Nitro storage as cache. Pattern mirrors getOrFetchIssues.
+ */
+export async function getOrFetchPullRequests(
+  token: string,
+  minimalNodes: MinimalPullRequestNode[],
+): Promise<PullRequest[]> {
+  if (!minimalNodes.length) return []
+
+  const storage = useStorage('data')
+  const resolvedNodes: GraphQLPullRequestNode[] = []
+  const missingIds: string[] = []
+
+  const cacheChecks = await Promise.all(
+    minimalNodes.map(async (node) => {
+      const cached = await storage.getItem<CachedPullRequestNode>(`pull-requests:${node.id}`)
+      return { node, cached }
+    }),
+  )
+
+  for (const { node, cached } of cacheChecks) {
+    if (cached && cached.node && cached.updatedAt === node.updatedAt) {
+      resolvedNodes.push(cached.node)
+    }
+    else {
+      missingIds.push(node.id)
+    }
+  }
+
+  if (missingIds.length) {
+    const data = await githubGraphQL<{ nodes: (GraphQLPullRequestNode | null)[] }>(
+      token,
+      NODES_QUERY,
+      { ids: missingIds },
+    )
+
+    const freshNodes = data.nodes.filter(
+      (n): n is GraphQLPullRequestNode => n !== null && 'id' in n,
+    )
+
+    await Promise.all(
+      freshNodes.map(async (node) => {
+        await storage.setItem<CachedPullRequestNode>(`pull-requests:${node.id}`, {
+          updatedAt: node.updatedAt,
+          node,
+        })
+      }),
+    )
+
+    resolvedNodes.push(...freshNodes)
+  }
+
+  const prs = resolvedNodes.filter(Boolean).map(n => toPullRequest(n))
+
+  const orderMap = new Map(minimalNodes.map((n, i) => [n.id, i]))
+  prs.sort((a, b) => (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0))
+
+  return prs
+}

--- a/server/utils/pull-request-search.ts
+++ b/server/utils/pull-request-search.ts
@@ -1,0 +1,58 @@
+import type { MinimalPullRequestNode } from '~~/shared/types/pull-request'
+
+const MINIMAL_SEARCH_QUERY = `
+query($query: String!, $first: Int!, $after: String) {
+  search(query: $query, type: ISSUE, first: $first, after: $after) {
+    issueCount
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        id
+        number
+        updatedAt
+        repository { nameWithOwner name owner { login } }
+      }
+    }
+  }
+}
+`
+
+interface MinimalSearchResult {
+  search: {
+    issueCount: number
+    pageInfo: { hasNextPage: boolean, endCursor: string | null }
+    nodes: (MinimalPullRequestNode | null)[]
+  }
+}
+
+export interface PullRequestSearchPage {
+  totalCount: number
+  pageInfo: { hasNextPage: boolean, endCursor: string | null }
+  minimalNodes: MinimalPullRequestNode[]
+}
+
+/**
+ * Run a GitHub search query for pull requests and return minimal nodes plus
+ * pagination info. The caller resolves full PR objects via `getOrFetchPullRequests`.
+ */
+export async function searchPullRequests(
+  token: string,
+  query: string,
+  options: { first: number, after?: string | null },
+): Promise<PullRequestSearchPage> {
+  const data = await githubGraphQL<MinimalSearchResult>(token, MINIMAL_SEARCH_QUERY, {
+    query,
+    first: options.first,
+    after: options.after ?? null,
+  })
+
+  const minimalNodes = data.search.nodes.filter(
+    (n): n is MinimalPullRequestNode => n !== null && 'id' in n,
+  )
+
+  return {
+    totalCount: data.search.issueCount,
+    pageInfo: data.search.pageInfo,
+    minimalNodes,
+  }
+}

--- a/shared/types/pull-request.ts
+++ b/shared/types/pull-request.ts
@@ -1,0 +1,79 @@
+import type { PageInfo } from './pagination'
+import type { CIStatus } from './waiting-on-me'
+
+export type PullRequestState = 'OPEN' | 'CLOSED' | 'MERGED'
+export type Mergeable = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+export type ReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null
+
+/**
+ * List-row representation of a pull request. Keep this lighter than the
+ * detail type — anything required for cards/rows/categorization only.
+ */
+export interface PullRequest {
+  id: string
+  number: number
+  title: string
+  state: PullRequestState
+  isDraft: boolean
+  url: string
+  createdAt: string
+  updatedAt: string
+  closedAt: string | null
+  mergedAt: string | null
+
+  author: {
+    login: string
+    avatarUrl: string
+  }
+
+  labels: Array<{
+    name: string
+    color: string
+  }>
+
+  assignees: Array<{
+    login: string
+    avatarUrl: string
+  }>
+
+  requestedReviewers: Array<{
+    login: string
+    avatarUrl: string
+  }>
+
+  reviewDecision: ReviewDecision
+  ciStatus: CIStatus
+  mergeable: Mergeable
+
+  additions: number
+  deletions: number
+  changedFiles: number
+  commentCount: number
+  linkedIssueCount: number
+
+  headRefName: string
+  baseRefName: string
+
+  repository: {
+    nameWithOwner: string
+    name: string
+    owner: { login: string }
+  }
+}
+
+export interface MinimalPullRequestNode {
+  id: string
+  number: number
+  updatedAt: string
+  repository: {
+    nameWithOwner: string
+    name: string
+    owner: { login: string }
+  }
+}
+
+export interface PullRequestListResponse {
+  items: PullRequest[]
+  totalCount: number
+  pageInfo: PageInfo
+}

--- a/shared/utils/pull-request.ts
+++ b/shared/utils/pull-request.ts
@@ -1,0 +1,82 @@
+import type { Mergeable, PullRequest, PullRequestState, ReviewDecision } from '../types/pull-request'
+import type { CIStatus } from '../types/waiting-on-me'
+
+export interface GraphQLPullRequestNode {
+  id: string
+  number: number
+  title: string
+  state: PullRequestState
+  isDraft: boolean
+  url: string
+  createdAt: string
+  updatedAt: string
+  closedAt: string | null
+  mergedAt: string | null
+  additions: number
+  deletions: number
+  changedFiles: number
+  headRefName: string
+  baseRefName: string
+  mergeable: Mergeable
+  reviewDecision: ReviewDecision
+  author: { login: string, avatarUrl: string } | null
+  labels: { nodes: Array<{ name: string, color: string }> }
+  assignees: { nodes: Array<{ login: string, avatarUrl: string }> }
+  reviewRequests: {
+    nodes: Array<{ requestedReviewer: { login: string, avatarUrl: string } | null }>
+  }
+  comments: { totalCount: number }
+  closingIssuesReferences: { totalCount: number }
+  commits: {
+    nodes: Array<{
+      commit: { statusCheckRollup: { state: string } | null }
+    }>
+  }
+  repository: {
+    nameWithOwner: string
+    name: string
+    owner: { login: string }
+  }
+}
+
+function extractCIStatus(node: GraphQLPullRequestNode): CIStatus {
+  const state = node.commits.nodes[0]?.commit.statusCheckRollup?.state
+  if (!state) return null
+  if (state === 'SUCCESS' || state === 'FAILURE' || state === 'ERROR'
+    || state === 'PENDING' || state === 'EXPECTED') {
+    return state
+  }
+  return null
+}
+
+export function toPullRequest(node: GraphQLPullRequestNode): PullRequest {
+  return {
+    id: node.id,
+    number: node.number,
+    title: node.title,
+    state: node.state,
+    isDraft: node.isDraft,
+    url: node.url,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    closedAt: node.closedAt,
+    mergedAt: node.mergedAt,
+    author: node.author ?? { login: 'ghost', avatarUrl: '' },
+    labels: node.labels.nodes,
+    assignees: node.assignees.nodes,
+    requestedReviewers: node.reviewRequests.nodes
+      .map(n => n.requestedReviewer)
+      .filter((r): r is { login: string, avatarUrl: string } => r !== null),
+    reviewDecision: node.reviewDecision,
+    ciStatus: extractCIStatus(node),
+    mergeable: node.mergeable,
+    additions: node.additions,
+    deletions: node.deletions,
+    changedFiles: node.changedFiles,
+    commentCount: node.comments.totalCount,
+    linkedIssueCount: node.closingIssuesReferences.totalCount,
+    headRefName: node.headRefName,
+    baseRefName: node.baseRefName,
+    repository: node.repository,
+  }
+}

--- a/test/unit/pullRequestMapper.test.ts
+++ b/test/unit/pullRequestMapper.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import type { GraphQLPullRequestNode } from '../../shared/utils/pull-request'
+import { toPullRequest } from '../../shared/utils/pull-request'
+
+function makeNode(overrides: Partial<GraphQLPullRequestNode> = {}): GraphQLPullRequestNode {
+  return {
+    id: 'PR_1',
+    number: 42,
+    title: 'Test PR',
+    state: 'OPEN',
+    isDraft: false,
+    url: 'https://github.com/org/repo/pull/42',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+    closedAt: null,
+    mergedAt: null,
+    additions: 10,
+    deletions: 2,
+    changedFiles: 3,
+    headRefName: 'feat/test',
+    baseRefName: 'main',
+    mergeable: 'MERGEABLE',
+    reviewDecision: null,
+    author: { login: 'alice', avatarUrl: 'https://example.com/a.png' },
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+    reviewRequests: { nodes: [] },
+    comments: { totalCount: 0 },
+    closingIssuesReferences: { totalCount: 0 },
+    commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    repository: {
+      nameWithOwner: 'org/repo',
+      name: 'repo',
+      owner: { login: 'org' },
+    },
+    ...overrides,
+  }
+}
+
+describe('toPullRequest', () => {
+  it('maps basic fields straight through', () => {
+    const pr = toPullRequest(makeNode())
+    expect(pr.id).toBe('PR_1')
+    expect(pr.number).toBe(42)
+    expect(pr.title).toBe('Test PR')
+    expect(pr.state).toBe('OPEN')
+    expect(pr.isDraft).toBe(false)
+    expect(pr.author.login).toBe('alice')
+    expect(pr.headRefName).toBe('feat/test')
+    expect(pr.baseRefName).toBe('main')
+    expect(pr.repository.nameWithOwner).toBe('org/repo')
+  })
+
+  it('flattens nested arrays into the row-level shape', () => {
+    const pr = toPullRequest(makeNode({
+      labels: { nodes: [{ name: 'bug', color: 'ff0000' }] },
+      assignees: { nodes: [{ login: 'bob', avatarUrl: 'b.png' }] },
+      comments: { totalCount: 7 },
+      closingIssuesReferences: { totalCount: 2 },
+    }))
+    expect(pr.labels).toEqual([{ name: 'bug', color: 'ff0000' }])
+    expect(pr.assignees).toEqual([{ login: 'bob', avatarUrl: 'b.png' }])
+    expect(pr.commentCount).toBe(7)
+    expect(pr.linkedIssueCount).toBe(2)
+  })
+
+  it('falls back to ghost when author is null (deleted account)', () => {
+    const pr = toPullRequest(makeNode({ author: null }))
+    expect(pr.author.login).toBe('ghost')
+    expect(pr.author.avatarUrl).toBe('')
+  })
+
+  it('filters out null requested reviewers (e.g. deleted users / unsupported types)', () => {
+    const pr = toPullRequest(makeNode({
+      reviewRequests: {
+        nodes: [
+          { requestedReviewer: { login: 'reviewer1', avatarUrl: 'r1.png' } },
+          { requestedReviewer: null },
+          { requestedReviewer: { login: 'reviewer2', avatarUrl: 'r2.png' } },
+        ],
+      },
+    }))
+    expect(pr.requestedReviewers).toEqual([
+      { login: 'reviewer1', avatarUrl: 'r1.png' },
+      { login: 'reviewer2', avatarUrl: 'r2.png' },
+    ])
+  })
+
+  it.each([
+    ['SUCCESS'],
+    ['FAILURE'],
+    ['ERROR'],
+    ['PENDING'],
+    ['EXPECTED'],
+  ] as const)('extracts known CI state %s', (state) => {
+    const pr = toPullRequest(makeNode({
+      commits: { nodes: [{ commit: { statusCheckRollup: { state } } }] },
+    }))
+    expect(pr.ciStatus).toBe(state)
+  })
+
+  it('returns null ciStatus when no statusCheckRollup is present (no CI configured)', () => {
+    const pr = toPullRequest(makeNode({
+      commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    }))
+    expect(pr.ciStatus).toBeNull()
+  })
+
+  it('returns null ciStatus for unrecognized rollup states', () => {
+    const pr = toPullRequest(makeNode({
+      commits: { nodes: [{ commit: { statusCheckRollup: { state: 'UNRECOGNIZED' } } }] },
+    }))
+    expect(pr.ciStatus).toBeNull()
+  })
+
+  it('returns null ciStatus when commits array is empty', () => {
+    const pr = toPullRequest(makeNode({
+      commits: { nodes: [] },
+    }))
+    expect(pr.ciStatus).toBeNull()
+  })
+
+  it('preserves reviewDecision and mergeable verbatim', () => {
+    const pr = toPullRequest(makeNode({
+      reviewDecision: 'APPROVED',
+      mergeable: 'CONFLICTING',
+    }))
+    expect(pr.reviewDecision).toBe('APPROVED')
+    expect(pr.mergeable).toBe('CONFLICTING')
+  })
+})


### PR DESCRIPTION
Closes #292.

PR list page with two compact highlight cards on top and the full open-PR list below. Highlight definitions are pinned to GitHub Search qualifiers — no maintainer-permission heuristic.

- **Ready to merge**: `is:pr is:open draft:false review:approved status:success` + client-side `mergeable !== CONFLICTING`
- **Reviews requested**: `is:pr is:open draft:false review-requested:@me`

Each card paginates independently (12 per page, configurable via `HIGHLIGHT_CARD_VISIBLE_ITEMS`). Main list paginates 20 per page.

Follow-up issue #304 tracks extracting a generic `<RepoSelect>` so `/pulls` doesn't depend on `<IssueRepoSelect>` anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull Requests page with Open/Merged/Closed filters, highlight cards (ready-to-merge, reviews-requested), and paginator.
  * Sidebar “Pulls” navigation and full English/German localization for PR flows.
* **Improvements**
  * Faster and more reliable PR loading and paging.
* **Tests**
  * Unit tests covering PR mapping and CI status extraction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->