### PR TITLE
feat(prs): row data signals — CI, approvals, mergeable, diff, linked

### DIFF
--- a/app/components/pull-request/PullRequestRow.vue
+++ b/app/components/pull-request/PullRequestRow.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
   pr: PullRequest
 }>()
 
+const { t } = useI18n()
 const localePath = useLocalePath()
 const { open: openProfile } = useUserProfileDialog()
 const createdAgo = useTimeAgo(computed(() => props.pr.createdAt))
@@ -24,6 +25,40 @@ const stateColor = computed(() => {
   if (props.pr.state === 'CLOSED') return 'text-rose-500'
   if (props.pr.isDraft) return 'text-neutral-400'
   return 'text-emerald-500'
+})
+
+const ci = computed(() => {
+  switch (props.pr.ciStatus) {
+    case 'SUCCESS': return { icon: 'i-lucide-check-circle-2', color: 'text-emerald-500', tooltip: t('pulls.ci.success') }
+    case 'FAILURE':
+    case 'ERROR': return { icon: 'i-lucide-x-circle', color: 'text-rose-500', tooltip: t('pulls.ci.failure') }
+    case 'PENDING': return { icon: 'i-lucide-clock', color: 'text-amber-500', tooltip: t('pulls.ci.pending') }
+    case 'EXPECTED': return { icon: 'i-lucide-clock', color: 'text-neutral-400', tooltip: t('pulls.ci.expected') }
+    default: return null
+  }
+})
+
+const approvedCount = computed(() =>
+  props.pr.latestReviews.filter(r => r.state === 'APPROVED').length,
+)
+const changesRequestedCount = computed(() =>
+  props.pr.latestReviews.filter(r => r.state === 'CHANGES_REQUESTED').length,
+)
+
+const approvedTooltip = computed(() => {
+  const logins = props.pr.latestReviews
+    .filter(r => r.state === 'APPROVED')
+    .map(r => r.author.login)
+    .join(', ')
+  return t('pulls.review.approvedBy', { logins })
+})
+
+const changesTooltip = computed(() => {
+  const logins = props.pr.latestReviews
+    .filter(r => r.state === 'CHANGES_REQUESTED')
+    .map(r => r.author.login)
+    .join(', ')
+  return t('pulls.review.changesRequestedBy', { logins })
 })
 
 const router = useRouter()
@@ -84,6 +119,83 @@ function navigate() {
         <span>#{{ pr.number }}</span>
         <span>{{ createdAgo }}</span>
         <span class="text-default">{{ updatedAgo }}</span>
+
+        <UTooltip
+          v-if="ci"
+          :text="ci.tooltip"
+        >
+          <UIcon
+            :name="ci.icon"
+            class="size-3.5"
+            :class="ci.color"
+          />
+        </UTooltip>
+
+        <UTooltip
+          v-if="approvedCount"
+          :text="approvedTooltip"
+        >
+          <span class="inline-flex items-center gap-0.5 text-emerald-500">
+            <UIcon
+              name="i-lucide-check"
+              class="size-3.5"
+            />
+            {{ approvedCount }}
+          </span>
+        </UTooltip>
+
+        <UTooltip
+          v-if="changesRequestedCount"
+          :text="changesTooltip"
+        >
+          <span class="inline-flex items-center gap-0.5 text-rose-500">
+            <UIcon
+              name="i-lucide-x"
+              class="size-3.5"
+            />
+            {{ changesRequestedCount }}
+          </span>
+        </UTooltip>
+
+        <UTooltip
+          v-if="pr.mergeable === 'CONFLICTING'"
+          :text="t('pulls.merge.conflicting')"
+        >
+          <UIcon
+            name="i-lucide-alert-triangle"
+            class="size-3.5 text-rose-500"
+          />
+        </UTooltip>
+
+        <span class="font-mono text-[10px] tabular-nums">
+          <span class="text-emerald-500">+{{ pr.additions }}</span>
+          <span class="text-rose-500 ml-1">−{{ pr.deletions }}</span>
+        </span>
+
+        <UTooltip
+          v-if="pr.linkedIssueCount"
+          :text="t('pulls.linkedIssues', { count: pr.linkedIssueCount })"
+        >
+          <span class="inline-flex items-center gap-0.5">
+            <UIcon
+              name="i-lucide-link-2"
+              class="size-3.5"
+            />
+            {{ pr.linkedIssueCount }}
+          </span>
+        </UTooltip>
+
+        <span
+          v-if="pr.commentCount"
+          class="inline-flex items-center gap-0.5"
+        >
+          <UIcon
+            name="i-lucide-message-square"
+            class="size-3.5"
+          />
+          {{ pr.commentCount }}
+        </span>
+
         <span class="font-mono text-[10px] text-muted/70 truncate max-w-35">
           {{ pr.headRefName }} → {{ pr.baseRefName }}
         </span>

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -22,6 +22,20 @@
     "merged": "Gemergt",
     "closed": "Geschlossen",
     "empty": "Keine Pull Requests in diesem Status.",
+    "linkedIssues": "{count} verknüpftes Issue | {count} verknüpfte Issues",
+    "ci": {
+      "success": "CI grün",
+      "failure": "CI rot",
+      "pending": "CI läuft",
+      "expected": "CI erwartet"
+    },
+    "review": {
+      "approvedBy": "Approved von {logins}",
+      "changesRequestedBy": "Changes angefordert von {logins}"
+    },
+    "merge": {
+      "conflicting": "Merge-Konflikt — Rebase nötig"
+    },
     "highlight": {
       "readyToMerge": "Bereit zum Mergen",
       "readyToMergeEmpty": "Aktuell ist nichts von dir komplett grün.",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -30,8 +30,8 @@
       "expected": "CI erwartet"
     },
     "review": {
-      "approvedBy": "Approved von {logins}",
-      "changesRequestedBy": "Changes angefordert von {logins}"
+      "approvedBy": "Genehmigt von {logins}",
+      "changesRequestedBy": "Änderungen angefordert von {logins}"
     },
     "merge": {
       "conflicting": "Merge-Konflikt — Rebase nötig"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -22,6 +22,20 @@
     "merged": "Merged",
     "closed": "Closed",
     "empty": "No pull requests in this state.",
+    "linkedIssues": "{count} linked issue | {count} linked issues",
+    "ci": {
+      "success": "CI passing",
+      "failure": "CI failing",
+      "pending": "CI running",
+      "expected": "CI expected"
+    },
+    "review": {
+      "approvedBy": "Approved by {logins}",
+      "changesRequestedBy": "Changes requested by {logins}"
+    },
+    "merge": {
+      "conflicting": "Merge conflict — needs rebase"
+    },
     "highlight": {
       "readyToMerge": "Ready to merge",
       "readyToMergeEmpty": "Nothing of yours is fully green right now.",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -73,6 +73,48 @@
         "empty": {
           "type": "string"
         },
+        "linkedIssues": {
+          "type": "string"
+        },
+        "ci": {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "string"
+            },
+            "failure": {
+              "type": "string"
+            },
+            "pending": {
+              "type": "string"
+            },
+            "expected": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "review": {
+          "type": "object",
+          "properties": {
+            "approvedBy": {
+              "type": "string"
+            },
+            "changesRequestedBy": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "merge": {
+          "type": "object",
+          "properties": {
+            "conflicting": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "highlight": {
           "type": "object",
           "properties": {

--- a/server/utils/pull-request-cache.ts
+++ b/server/utils/pull-request-cache.ts
@@ -32,6 +32,12 @@ const PR_FIELDS = `
   }
   comments { totalCount }
   closingIssuesReferences(first: 0) { totalCount }
+  latestReviews(first: 10) {
+    nodes {
+      state
+      author { login avatarUrl }
+    }
+  }
   commits(last: 1) {
     nodes {
       commit { statusCheckRollup { state } }

--- a/shared/types/pull-request.ts
+++ b/shared/types/pull-request.ts
@@ -4,6 +4,7 @@ import type { CIStatus } from './waiting-on-me'
 export type PullRequestState = 'OPEN' | 'CLOSED' | 'MERGED'
 export type Mergeable = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type ReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null
+export type ReviewState = 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING' | 'DISMISSED'
 
 /**
  * List-row representation of a pull request. Keep this lighter than the
@@ -44,6 +45,12 @@ export interface PullRequest {
   reviewDecision: ReviewDecision
   ciStatus: CIStatus
   mergeable: Mergeable
+
+  /** Most recent review per reviewer — used to render the approval counter. */
+  latestReviews: Array<{
+    state: ReviewState
+    author: { login: string, avatarUrl: string }
+  }>
 
   additions: number
   deletions: number

--- a/shared/utils/pull-request.ts
+++ b/shared/utils/pull-request.ts
@@ -1,4 +1,4 @@
-import type { Mergeable, PullRequest, PullRequestState, ReviewDecision } from '../types/pull-request'
+import type { Mergeable, PullRequest, PullRequestState, ReviewDecision, ReviewState } from '../types/pull-request'
 import type { CIStatus } from '../types/waiting-on-me'
 
 export interface GraphQLPullRequestNode {
@@ -27,6 +27,12 @@ export interface GraphQLPullRequestNode {
   }
   comments: { totalCount: number }
   closingIssuesReferences: { totalCount: number }
+  latestReviews: {
+    nodes: Array<{
+      state: ReviewState
+      author: { login: string, avatarUrl: string } | null
+    }>
+  }
   commits: {
     nodes: Array<{
       commit: { statusCheckRollup: { state: string } | null }
@@ -70,6 +76,9 @@ export function toPullRequest(node: GraphQLPullRequestNode): PullRequest {
     reviewDecision: node.reviewDecision,
     ciStatus: extractCIStatus(node),
     mergeable: node.mergeable,
+    latestReviews: (node.latestReviews?.nodes ?? [])
+      .filter(r => r.author !== null)
+      .map(r => ({ state: r.state, author: r.author! })),
     additions: node.additions,
     deletions: node.deletions,
     changedFiles: node.changedFiles,

--- a/test/unit/pullRequestMapper.test.ts
+++ b/test/unit/pullRequestMapper.test.ts
@@ -28,6 +28,7 @@ function makeNode(overrides: Partial<GraphQLPullRequestNode> = {}): GraphQLPullR
     comments: { totalCount: 0 },
     closingIssuesReferences: { totalCount: 0 },
     commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+    latestReviews: { nodes: [] },
     repository: {
       nameWithOwner: 'org/repo',
       name: 'repo',
@@ -127,5 +128,33 @@ describe('toPullRequest', () => {
     }))
     expect(pr.reviewDecision).toBe('APPROVED')
     expect(pr.mergeable).toBe('CONFLICTING')
+  })
+
+  it('maps latestReviews into the row-level shape', () => {
+    const pr = toPullRequest(makeNode({
+      latestReviews: {
+        nodes: [
+          { state: 'APPROVED', author: { login: 'alice', avatarUrl: 'a.png' } },
+          { state: 'CHANGES_REQUESTED', author: { login: 'bob', avatarUrl: 'b.png' } },
+        ],
+      },
+    }))
+    expect(pr.latestReviews).toEqual([
+      { state: 'APPROVED', author: { login: 'alice', avatarUrl: 'a.png' } },
+      { state: 'CHANGES_REQUESTED', author: { login: 'bob', avatarUrl: 'b.png' } },
+    ])
+  })
+
+  it('drops latestReviews entries whose author is null (deleted accounts)', () => {
+    const pr = toPullRequest(makeNode({
+      latestReviews: {
+        nodes: [
+          { state: 'APPROVED', author: { login: 'alice', avatarUrl: 'a.png' } },
+          { state: 'COMMENTED', author: null },
+        ],
+      },
+    }))
+    expect(pr.latestReviews).toHaveLength(1)
+    expect(pr.latestReviews[0]?.author.login).toBe('alice')
   })
 })


### PR DESCRIPTION
Closes #293.

Per-row signals in the meta line of the PR main list, each only rendered when relevant:

- CI-status glyph (success/failure/pending/expected)
- Approval counter (`✓ N` from `latestReviews`)
- Changes-requested counter (`✗ N`)
- Conflict warning (only when `mergeable === CONFLICTING`)
- Diff stats (`+additions −deletions`)
- Linked-issue count (only when `closingIssuesReferences > 0`)
- Comment count (only when present)

Adds `latestReviews` to `PullRequest` type + GraphQL fragment + mapper. Mapper reads it defensively (`?.nodes ?? []`) so older cached nodes without the field don't crash the endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request rows now show CI status (icons/colors/tooltips), review counts with reviewer tooltips, merge-conflict indicator, additions/deletions, and linked-issues count.
* **Internationalization**
  * Added English and German strings for linked issues, CI statuses, review attributions, and merge conflict messaging.
* **Tests**
  * Added unit tests to cover mapping and filtering of latest review data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/307)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->