### PR TITLE
feat(prs): inline expansion of linked issues on rows

### DIFF
--- a/app/components/pull-request/PullRequestRow.vue
+++ b/app/components/pull-request/PullRequestRow.vue
@@ -66,160 +66,233 @@ const router = useRouter()
 function navigate() {
   router.push(localePath(buildWorkItemPath(repo.value, props.pr.number)!))
 }
+
+const linkedIssuesStore = useLinkedIssuesStore()
+const isExpanded = computed(() => linkedIssuesStore.isExpanded(props.pr.id))
+const isLoadingLinked = computed(() => linkedIssuesStore.isLoading(props.pr.id))
+const linkedItems = computed(() => linkedIssuesStore.items(props.pr.id))
+
+function toggleExpand() {
+  linkedIssuesStore.toggle(props.pr.id, repo.value, props.pr.number)
+}
+
+function linkedIssueState(state: 'OPEN' | 'CLOSED', stateReason: string | null) {
+  if (state === 'OPEN') return { icon: 'i-lucide-circle-dot', color: 'text-emerald-500' }
+  if (stateReason === 'NOT_PLANNED') return { icon: 'i-lucide-circle-slash', color: 'text-neutral-400' }
+  return { icon: 'i-lucide-check-circle', color: 'text-violet-500' }
+}
 </script>
 
 <template>
-  <div
-    role="link"
-    tabindex="0"
-    class="group flex items-start gap-2 sm:gap-3 px-2 py-2.5 sm:px-4 sm:py-3 hover:bg-elevated transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-elevated"
-    @click="navigate"
-    @keydown.enter.self="navigate"
-    @keydown.space.self.prevent="navigate"
-  >
-    <UIcon
-      :name="stateIcon"
-      class="size-5 mt-0.5 shrink-0"
-      :class="stateColor"
-    />
+  <article>
+    <div
+      role="link"
+      tabindex="0"
+      class="group flex items-start gap-2 sm:gap-3 px-2 py-2.5 sm:px-4 sm:py-3 hover:bg-elevated transition-colors cursor-pointer focus-visible:outline-none focus-visible:bg-elevated"
+      @click="navigate"
+      @keydown.enter.self="navigate"
+      @keydown.space.self.prevent="navigate"
+    >
+      <UIcon
+        :name="stateIcon"
+        class="size-5 mt-0.5 shrink-0"
+        :class="stateColor"
+      />
 
-    <div class="min-w-0 flex-1">
-      <div class="flex items-center gap-2 flex-wrap">
-        <span class="font-medium text-highlighted hover:underline text-sm sm:text-base">
-          {{ pr.title }}
-        </span>
-        <UBadge
-          v-for="label in pr.labels"
-          :key="label.name"
-          color="neutral"
-          variant="subtle"
-          size="xs"
-          :style="{
-            backgroundColor: `#${label.color}1a`,
-            color: `#${label.color}`,
-          }"
-        >
-          {{ label.name }}
-        </UBadge>
-      </div>
-
-      <div class="flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3 mt-1 text-xs text-muted">
-        <button
-          type="button"
-          class="inline-flex items-center gap-1 cursor-pointer hover:underline"
-          @click.stop="openProfile(pr.author.login)"
-        >
-          <UAvatar
-            :src="pr.author.avatarUrl"
-            :alt="pr.author.login"
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="font-medium text-highlighted hover:underline text-sm sm:text-base">
+            {{ pr.title }}
+          </span>
+          <UBadge
+            v-for="label in pr.labels"
+            :key="label.name"
+            color="neutral"
+            variant="subtle"
             size="xs"
-          />
-          {{ pr.author.login }}
-        </button>
-        <span>#{{ pr.number }}</span>
-        <span>{{ createdAgo }}</span>
-        <span class="text-default">{{ updatedAgo }}</span>
+            :style="{
+              backgroundColor: `#${label.color}1a`,
+              color: `#${label.color}`,
+            }"
+          >
+            {{ label.name }}
+          </UBadge>
 
-        <UTooltip
-          v-if="ci"
-          :text="ci.tooltip"
-        >
-          <UIcon
-            :name="ci.icon"
-            class="size-3.5"
-            :class="ci.color"
-          />
-        </UTooltip>
-
-        <UTooltip
-          v-if="approvedCount"
-          :text="approvedTooltip"
-        >
-          <span class="inline-flex items-center gap-0.5 text-emerald-500">
+          <button
+            v-if="pr.linkedIssueCount"
+            type="button"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-blue-500/10 text-blue-500 text-xs font-medium hover:bg-blue-500/20 cursor-pointer transition-colors"
+            :aria-expanded="isExpanded"
+            @click.stop="toggleExpand"
+          >
             <UIcon
-              name="i-lucide-check"
+              :name="isExpanded ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
               class="size-3.5"
             />
-            {{ approvedCount }}
-          </span>
-        </UTooltip>
-
-        <UTooltip
-          v-if="changesRequestedCount"
-          :text="changesTooltip"
-        >
-          <span class="inline-flex items-center gap-0.5 text-rose-500">
-            <UIcon
-              name="i-lucide-x"
-              class="size-3.5"
-            />
-            {{ changesRequestedCount }}
-          </span>
-        </UTooltip>
-
-        <UTooltip
-          v-if="pr.mergeable === 'CONFLICTING'"
-          :text="t('pulls.merge.conflicting')"
-        >
-          <UIcon
-            name="i-lucide-alert-triangle"
-            class="size-3.5 text-rose-500"
-          />
-        </UTooltip>
-
-        <span class="font-mono text-[10px] tabular-nums">
-          <span class="text-emerald-500">+{{ pr.additions }}</span>
-          <span class="text-rose-500 ml-1">−{{ pr.deletions }}</span>
-        </span>
-
-        <UTooltip
-          v-if="pr.linkedIssueCount"
-          :text="t('pulls.linkedIssues', { count: pr.linkedIssueCount })"
-        >
-          <span class="inline-flex items-center gap-0.5">
             <UIcon
               name="i-lucide-link-2"
               class="size-3.5"
             />
-            {{ pr.linkedIssueCount }}
+            {{ t('pulls.linkedIssues', { count: pr.linkedIssueCount }) }}
+          </button>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-3 mt-1 text-xs text-muted">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 cursor-pointer hover:underline"
+            @click.stop="openProfile(pr.author.login)"
+          >
+            <UAvatar
+              :src="pr.author.avatarUrl"
+              :alt="pr.author.login"
+              size="xs"
+            />
+            {{ pr.author.login }}
+          </button>
+          <span>#{{ pr.number }}</span>
+          <span>{{ createdAgo }}</span>
+          <span class="text-default">{{ updatedAgo }}</span>
+
+          <UTooltip
+            v-if="ci"
+            :text="ci.tooltip"
+          >
+            <UIcon
+              :name="ci.icon"
+              class="size-3.5"
+              :class="ci.color"
+            />
+          </UTooltip>
+
+          <UTooltip
+            v-if="approvedCount"
+            :text="approvedTooltip"
+          >
+            <span class="inline-flex items-center gap-0.5 text-emerald-500">
+              <UIcon
+                name="i-lucide-check"
+                class="size-3.5"
+              />
+              {{ approvedCount }}
+            </span>
+          </UTooltip>
+
+          <UTooltip
+            v-if="changesRequestedCount"
+            :text="changesTooltip"
+          >
+            <span class="inline-flex items-center gap-0.5 text-rose-500">
+              <UIcon
+                name="i-lucide-x"
+                class="size-3.5"
+              />
+              {{ changesRequestedCount }}
+            </span>
+          </UTooltip>
+
+          <UTooltip
+            v-if="pr.mergeable === 'CONFLICTING'"
+            :text="t('pulls.merge.conflicting')"
+          >
+            <UIcon
+              name="i-lucide-alert-triangle"
+              class="size-3.5 text-rose-500"
+            />
+          </UTooltip>
+
+          <span class="font-mono text-[10px] tabular-nums">
+            <span class="text-emerald-500">+{{ pr.additions }}</span>
+            <span class="text-rose-500 ml-1">−{{ pr.deletions }}</span>
           </span>
-        </UTooltip>
 
-        <span
-          v-if="pr.commentCount"
-          class="inline-flex items-center gap-0.5"
+          <span
+            v-if="pr.commentCount"
+            class="inline-flex items-center gap-0.5"
+          >
+            <UIcon
+              name="i-lucide-message-square"
+              class="size-3.5"
+            />
+            {{ pr.commentCount }}
+          </span>
+
+          <span class="font-mono text-[10px] text-muted/70 truncate max-w-35">
+            {{ pr.headRefName }} → {{ pr.baseRefName }}
+          </span>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-1 shrink-0">
+        <UTooltip
+          v-for="reviewer in pr.requestedReviewers"
+          :key="reviewer.login"
+          :text="reviewer.login"
         >
-          <UIcon
-            name="i-lucide-message-square"
-            class="size-3.5"
-          />
-          {{ pr.commentCount }}
-        </span>
-
-        <span class="font-mono text-[10px] text-muted/70 truncate max-w-35">
-          {{ pr.headRefName }} → {{ pr.baseRefName }}
-        </span>
+          <button
+            type="button"
+            class="cursor-pointer"
+            @click.stop="openProfile(reviewer.login)"
+          >
+            <UAvatar
+              :src="reviewer.avatarUrl"
+              :alt="reviewer.login"
+              size="xs"
+            />
+          </button>
+        </UTooltip>
       </div>
     </div>
 
-    <div class="flex items-center gap-1 shrink-0">
-      <UTooltip
-        v-for="reviewer in pr.requestedReviewers"
-        :key="reviewer.login"
-        :text="reviewer.login"
+    <div
+      v-if="isExpanded"
+      class="pl-9 sm:pl-12 pr-2 sm:pr-4 pb-2 bg-elevated/30"
+    >
+      <div
+        v-if="isLoadingLinked && !linkedItems.length"
+        class="py-2 flex items-center gap-2 text-xs text-muted"
       >
-        <button
-          type="button"
-          class="cursor-pointer"
-          @click.stop="openProfile(reviewer.login)"
+        <UIcon
+          name="i-lucide-loader"
+          class="size-3.5 animate-spin"
+        />
+        {{ t('common.loading') }}
+      </div>
+      <ul
+        v-else-if="linkedItems.length"
+        class="border-l-2 border-default/60 divide-y divide-default/40"
+      >
+        <li
+          v-for="issue in linkedItems"
+          :key="issue.id"
+          class="hover:bg-elevated transition-colors"
         >
-          <UAvatar
-            :src="reviewer.avatarUrl"
-            :alt="reviewer.login"
-            size="xs"
-          />
-        </button>
-      </UTooltip>
+          <NuxtLink
+            :to="localePath(buildWorkItemPath(issue.repository.nameWithOwner, issue.number)!)"
+            class="flex items-center gap-2 pl-3 pr-2 py-1.5 min-w-0 text-xs"
+          >
+            <UIcon
+              :name="linkedIssueState(issue.state, issue.stateReason).icon"
+              class="size-3.5 shrink-0"
+              :class="linkedIssueState(issue.state, issue.stateReason).color"
+            />
+            <span class="text-muted tabular-nums shrink-0">#{{ issue.number }}</span>
+            <span class="flex-1 min-w-0 text-default truncate hover:underline">{{ issue.title }}</span>
+            <UAvatar
+              :src="issue.author.avatarUrl"
+              :alt="issue.author.login"
+              size="2xs"
+              class="shrink-0"
+            />
+          </NuxtLink>
+        </li>
+      </ul>
+      <p
+        v-else
+        class="py-2 text-xs text-muted"
+      >
+        {{ t('pulls.linkedIssuesEmpty') }}
+      </p>
     </div>
-  </div>
+  </article>
 </template>

--- a/app/stores/linkedIssues.ts
+++ b/app/stores/linkedIssues.ts
@@ -1,0 +1,52 @@
+import type { LinkedIssue } from '~~/shared/types/linked-issue'
+
+/**
+ * Tracks which PR rows are expanded to show their linked issues, plus a
+ * shared cache so we don't refetch when a row is collapsed and reopened.
+ */
+export const useLinkedIssuesStore = defineStore('linkedIssues', () => {
+  const apiFetch = useRequestFetch()
+
+  const expanded = ref<Set<string>>(new Set())
+  const cache = ref<Map<string, LinkedIssue[]>>(new Map())
+  const loading = ref<Set<string>>(new Set())
+
+  function isExpanded(prId: string): boolean {
+    return expanded.value.has(prId)
+  }
+
+  function isLoading(prId: string): boolean {
+    return loading.value.has(prId)
+  }
+
+  function items(prId: string): LinkedIssue[] {
+    return cache.value.get(prId) ?? []
+  }
+
+  async function toggle(prId: string, repo: string, number: number) {
+    if (expanded.value.has(prId)) {
+      expanded.value = new Set([...expanded.value].filter(id => id !== prId))
+      return
+    }
+    expanded.value = new Set([...expanded.value, prId])
+
+    if (cache.value.has(prId) || loading.value.has(prId)) return
+
+    loading.value = new Set([...loading.value, prId])
+    try {
+      const [owner, name] = repo.split('/')
+      const data = await apiFetch<LinkedIssue[]>(
+        `/api/repository/${owner}/${name}/pulls/${number}/linked-issues`,
+      )
+      cache.value.set(prId, data)
+    }
+    catch {
+      cache.value.set(prId, [])
+    }
+    finally {
+      loading.value = new Set([...loading.value].filter(id => id !== prId))
+    }
+  }
+
+  return { isExpanded, isLoading, items, toggle }
+})

--- a/app/stores/linkedIssues.ts
+++ b/app/stores/linkedIssues.ts
@@ -41,7 +41,8 @@ export const useLinkedIssuesStore = defineStore('linkedIssues', () => {
       cache.value.set(prId, data)
     }
     catch {
-      cache.value.set(prId, [])
+      // Leave cache untouched so the next toggle retries instead of showing a
+      // stale empty state forever.
     }
     finally {
       loading.value = new Set([...loading.value].filter(id => id !== prId))

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -23,6 +23,7 @@
     "closed": "Geschlossen",
     "empty": "Keine Pull Requests in diesem Status.",
     "linkedIssues": "{count} verknüpftes Issue | {count} verknüpfte Issues",
+    "linkedIssuesEmpty": "Keine verknüpften Issues gefunden.",
     "ci": {
       "success": "CI grün",
       "failure": "CI rot",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -23,6 +23,7 @@
     "closed": "Closed",
     "empty": "No pull requests in this state.",
     "linkedIssues": "{count} linked issue | {count} linked issues",
+    "linkedIssuesEmpty": "No linked issues found.",
     "ci": {
       "success": "CI passing",
       "failure": "CI failing",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -76,6 +76,9 @@
         "linkedIssues": {
           "type": "string"
         },
+        "linkedIssuesEmpty": {
+          "type": "string"
+        },
         "ci": {
           "type": "object",
           "properties": {

--- a/server/api/repository/[owner]/[repo]/pulls/[number]/linked-issues.get.ts
+++ b/server/api/repository/[owner]/[repo]/pulls/[number]/linked-issues.get.ts
@@ -1,0 +1,73 @@
+import type { LinkedIssue } from '~~/shared/types/linked-issue'
+
+const QUERY = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 20) {
+        nodes {
+          id
+          number
+          title
+          state
+          stateReason
+          url
+          author { login avatarUrl }
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+}
+`
+
+interface QueryResult {
+  repository: {
+    pullRequest: {
+      closingIssuesReferences: {
+        nodes: Array<{
+          id: string
+          number: number
+          title: string
+          state: 'OPEN' | 'CLOSED'
+          stateReason: 'COMPLETED' | 'NOT_PLANNED' | 'REOPENED' | null
+          url: string
+          author: { login: string, avatarUrl: string } | null
+          repository: { nameWithOwner: string }
+        }>
+      }
+    } | null
+  } | null
+}
+
+export default defineEventHandler(async (event): Promise<LinkedIssue[]> => {
+  const { token } = await getSessionToken(event)
+  const { owner, repo, number } = getRouterParams(event)
+
+  if (!owner || !repo || !number) {
+    throw createError({ statusCode: 400, message: 'Missing route params' })
+  }
+
+  const num = Number(number)
+  if (!Number.isInteger(num) || num <= 0) {
+    throw createError({ statusCode: 400, message: 'Invalid PR number' })
+  }
+
+  const data = await githubGraphQL<QueryResult>(token, QUERY, {
+    owner,
+    name: repo,
+    number: num,
+  })
+
+  const nodes = data.repository?.pullRequest?.closingIssuesReferences.nodes ?? []
+  return nodes.map(n => ({
+    id: n.id,
+    number: n.number,
+    title: n.title,
+    state: n.state,
+    stateReason: n.stateReason,
+    url: n.url,
+    author: n.author ?? { login: 'ghost', avatarUrl: '' },
+    repository: n.repository,
+  }))
+})

--- a/shared/types/linked-issue.ts
+++ b/shared/types/linked-issue.ts
@@ -1,0 +1,19 @@
+/**
+ * Compact issue representation for inline expansion under a PR row. Lighter
+ * than the full `Issue` type — just enough to render a one-line preview.
+ */
+export interface LinkedIssue {
+  id: string
+  number: number
+  title: string
+  state: 'OPEN' | 'CLOSED'
+  stateReason: 'COMPLETED' | 'NOT_PLANNED' | 'REOPENED' | null
+  url: string
+  author: {
+    login: string
+    avatarUrl: string
+  }
+  repository: {
+    nameWithOwner: string
+  }
+}


### PR DESCRIPTION
Closes #294.

Each PR row with `closingIssuesReferences > 0` gets a blue pill next to the labels (`▷ 🔗 N linked issues`). Click toggles an inline section beneath the row showing compact linked-issue rows (state-icon, #N, title, author) — click navigates to the issue.

- New endpoint `/api/repository/{owner}/{repo}/pulls/{number}/linked-issues` (GraphQL `closingIssuesReferences`)
- Small Pinia store `linkedIssues` for expansion state + per-PR cache (lazy fetch on first toggle)
- New `LinkedIssue` shared type — lighter than `Issue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request rows now include an expandable linked-issues section showing related issues on demand (loads when expanded)
  * Each linked issue shows state (icon/color), title, and author avatar
  * Loading indicator while linked issues fetch; clear empty-state message when none found

* **Localization**
  * Added English and German translations for the linked-issues empty message

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/308)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flumen-dev/flumen.dev/pull/308)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->